### PR TITLE
Bugfix for s3 utils listObjectsInBucketMatchingGlob, for file names w…

### DIFF
--- a/qqq-backend-module-filesystem/src/main/java/com/kingsrook/qqq/backend/module/filesystem/s3/utils/S3Utils.java
+++ b/qqq-backend-module-filesystem/src/main/java/com/kingsrook/qqq/backend/module/filesystem/s3/utils/S3Utils.java
@@ -25,6 +25,7 @@ package com.kingsrook.qqq.backend.module.filesystem.s3.utils;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
@@ -175,7 +176,7 @@ public class S3Utils
             ///////////////////////////////////////////
             // skip files that do not match the glob //
             ///////////////////////////////////////////
-            if(!pathMatcher.matches(Path.of(URI.create("file:///" + key))))
+            if(!pathMatcher.matches(Path.of(URI.create("file:///" + URLEncoder.encode(key)))))
             {
                // LOG.debug("Skipping file [{}] that does not match glob [{}]", key, glob);
                continue;

--- a/qqq-backend-module-filesystem/src/test/java/com/kingsrook/qqq/backend/module/filesystem/s3/BaseS3Test.java
+++ b/qqq-backend-module-filesystem/src/test/java/com/kingsrook/qqq/backend/module/filesystem/s3/BaseS3Test.java
@@ -66,7 +66,7 @@ public class BaseS3Test extends BaseTest
       amazonS3.putObject(BUCKET_NAME, TEST_FOLDER + "/" + SUB_FOLDER + "/3.csv", getCSVData3());
       amazonS3.putObject(BUCKET_NAME, TEST_FOLDER + "/blobs/BLOB-1.txt", "Hello, Blob");
       amazonS3.putObject(BUCKET_NAME, TEST_FOLDER + "/blobs/BLOB-2.txt", "Hi, Bob");
-      amazonS3.putObject(BUCKET_NAME, TEST_FOLDER + "/blobs/BLOB-3.md", "# Hi, MD");
+      amazonS3.putObject(BUCKET_NAME, TEST_FOLDER + "/blobs/BLOB 3.md", "# Hi, MD"); // this one, with a space in the name, tripped up listObjectsInBucketMatchingGlob's path matching at one time
 
       amazonS3.createBucket(BUCKET_NAME_FOR_SANS_PREFIX_BACKEND);
       amazonS3.putObject(BUCKET_NAME_FOR_SANS_PREFIX_BACKEND, "BLOB-1.txt", "Hello, Blob");


### PR DESCRIPTION
…ith chars that need URL Encoding (since we're using a pathMatcher class and file:/// URIs...)  update test setup to have a file that triggered this error before the fix.