### PR TITLE
Feature/circleci improvements

### DIFF
--- a/.circleci/collect-jacoco-reports.sh
+++ b/.circleci/collect-jacoco-reports.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+############################################################################
+## Script to collect all JaCoCo reports from different modules into a
+## single directory for easier artifact storage in CI.
+############################################################################
+
+mkdir -p /home/circleci/jacoco-reports/
+
+##############################################################
+## Find all module directories that have target/site/jacoco ##
+##############################################################
+for module_dir in */; do
+  if [ -d "${module_dir}target/site/jacoco" ]; then
+    module_name=$(basename "${module_dir%/}")
+    target_dir="/home/circleci/jacoco-reports/${module_name}"
+    
+    echo "Collecting JaCoCo reports for module: ${module_name}"
+    
+    cp -r "${module_dir}target/site/jacoco" "${target_dir}"
+    
+    echo "Copied JaCoCo reports for ${module_name} to ${target_dir}"
+  fi
+done
+
+echo "All JaCoCo reports collected to /home/circleci/jacoco-reports/" 

--- a/.circleci/concatenate-test-output.sh
+++ b/.circleci/concatenate-test-output.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+############################################################################
+## Script to concatenate all .txt files in the surefire-reports directory
+## into a single artifact that can be stored in CI.
+############################################################################
+
+mkdir -p /home/circleci/test-output-artifacts/
+
+###################################################################
+## Find all module directories that have target/surefire-reports ##
+###################################################################
+for module_dir in */; do
+  if [ -d "${module_dir}target/surefire-reports" ]; then
+    module_name=$(basename "${module_dir%/}")
+    output_file="/home/circleci/test-output-artifacts/${module_name}-test-output.txt"
+    
+    echo "Processing module: ${module_name}"
+    echo "Output file: ${output_file}"
+    
+    ##################################################################
+    ## Concatenate all .txt files in the surefire-reports directory ##
+    ##################################################################
+    if [ -n "$(find "${module_dir}target/surefire-reports" -name "*.txt" -type f)" ]; then
+      echo "=== Test Output for ${module_name} ===" > "${output_file}"
+      echo "Generated at: $(date)" >> "${output_file}"
+      echo "==========================================" >> "${output_file}"
+      echo "" >> "${output_file}"
+      
+      ##############################################
+      ## Sort files to ensure consistent ordering ##
+      ##############################################
+      find "${module_dir}target/surefire-reports" -name "*.txt" -type f | sort | while read -r txt_file; do
+        echo "--- File: $(basename "${txt_file}") ---" >> "${output_file}"
+        cat "${txt_file}" >> "${output_file}"
+        echo "" >> "${output_file}"
+        echo "--- End of $(basename "${txt_file}") ---" >> "${output_file}"
+        echo "" >> "${output_file}"
+        echo "" >> "${output_file}"
+        echo "" >> "${output_file}"
+      done
+      
+      echo "Concatenated test output for ${module_name} to ${output_file}"
+    else
+      echo "No .txt files found in ${module_dir}target/surefire-reports"
+    fi
+  fi
+done 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,13 @@ commands:
           name: Run Maven Verify
           command: |
             mvn -s .circleci/mvn-settings.xml -T4 --no-transfer-progress verify
+      - run:
+          name: Collect JaCoCo reports
+          command: .circleci/collect-jacoco-reports.sh
+          when: always
       - store_artifacts:
-          name: Store Jacoco reports
-          path: "*/target/site/jacoco/"
+          path: /home/circleci/jacoco-reports
+          destination: jacoco-reports
           when: always
       - run:
           name: Concatenate test output files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,21 +17,13 @@ commands:
           path: << parameters.module >>/target/site/jacoco/jacoco-resources
           when: always
 
-  install_java17:
+  check_java_version:
     steps:
       - run:
-          name: Install Java 17
+          name: Check Java Version
           command: |
-            sudo apt-get update
-            sudo apt install -y openjdk-17-jdk
-            sudo rm /etc/alternatives/java
-            sudo ln -s /usr/lib/jvm/java-17-openjdk-amd64/bin/java /etc/alternatives/java
-      - run:
-          ## used by jacoco uncovered class reporting in pom.xml
-          name: Install html2text
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y html2text
+            java -version
+            echo "Java version check completed"
 
   mvn_verify:
     steps:
@@ -139,7 +131,7 @@ jobs:
     executor: localstack/default
     steps:
       ## - localstack/startup
-      - install_java17
+      - check_java_version
       - mvn_verify
       - check_middleware_api_versions
 
@@ -147,7 +139,7 @@ jobs:
     executor: localstack/default
     steps:
       ## - localstack/startup
-      - install_java17
+      - check_java_version
       - mvn_verify
       - check_middleware_api_versions
       - mvn_jar_deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,6 @@ orbs:
   browser-tools: circleci/browser-tools@1.4.7
 
 commands:
-  check_java_version:
-    steps:
-      - run:
-          name: Check Java Version
-          command: |
-            java -version
-            echo "Java version check completed"
-
   mvn_build:
     steps:
       - checkout
@@ -43,12 +35,9 @@ commands:
       - run:
           name: Run Maven Test
           command: |
-            mvn -s .circleci/mvn-settings.xml -T4 --batch-mode test
+            mvn -s .circleci/mvn-settings.xml -T4 --batch-mode test jacoco:report
       - store_artifacts:
           path: "*/target/site/jacoco/"
-          when: always
-      - store_artifacts:
-          path: "*/target/test-logs/"
           when: always
       - run:
           name: Concatenate test output files
@@ -156,20 +145,24 @@ commands:
           when: always
 
 jobs:
-  mvn_test:
+  build:
     executor: localstack/default
     steps:
-      ## - localstack/startup
-      - check_java_version
       - mvn_build
+
+  test:
+    executor: localstack/default
+    steps:
       - mvn_test
+
+  api_version_check:
+    executor: localstack/default
+    steps:
       - check_middleware_api_versions
 
   mvn_deploy:
     executor: localstack/default
     steps:
-      ## - localstack/startup
-      - check_java_version
       - mvn_build
       - mvn_test
       - check_middleware_api_versions
@@ -184,8 +177,26 @@ jobs:
 workflows:
   test_only:
     jobs:
-      - mvn_test:
+      - build:
           context: [ qqq-maven-registry-credentials, build-qqq-sample-app ]
+          filters:
+            branches:
+              ignore: /(dev|integration.*)/
+            tags:
+              ignore: /(version|snapshot)-.*/
+      - test:
+          context: [ qqq-maven-registry-credentials, build-qqq-sample-app ]
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /(dev|integration.*)/
+            tags:
+              ignore: /(version|snapshot)-.*/
+      - api_version_check:
+          context: [ qqq-maven-registry-credentials, build-qqq-sample-app ]
+          requires:
+            - build
           filters:
             branches:
               ignore: /(dev|integration.*)/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,18 +5,6 @@ orbs:
   browser-tools: circleci/browser-tools@1.4.7
 
 commands:
-  store_jacoco_site:
-    parameters:
-      module:
-        type: string
-    steps:
-      - store_artifacts:
-          path: << parameters.module >>/target/site/jacoco/index.html
-          when: always
-      - store_artifacts:
-          path: << parameters.module >>/target/site/jacoco/jacoco-resources
-          when: always
-
   check_java_version:
     steps:
       - run:
@@ -41,26 +29,9 @@ commands:
           name: Run Maven Verify
           command: |
             mvn -s .circleci/mvn-settings.xml -T4 verify
-      - store_jacoco_site:
-          module: qqq-backend-core
-      - store_jacoco_site:
-          module: qqq-backend-module-filesystem
-      - store_jacoco_site:
-          module: qqq-backend-module-rdbms
-      - store_jacoco_site:
-          module: qqq-backend-module-api
-      - store_jacoco_site:
-          module: qqq-middleware-api
-      - store_jacoco_site:
-          module: qqq-middleware-javalin
-      - store_jacoco_site:
-          module: qqq-middleware-picocli
-      - store_jacoco_site:
-          module: qqq-middleware-slack
-      - store_jacoco_site:
-          module: qqq-language-support-javascript
-      - store_jacoco_site:
-          module: qqq-sample-project
+      - store_artifacts:
+          path: "*/target/site/jacoco/"
+          when: always
       - run:
           name: Save test results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,13 +39,13 @@ commands:
           name: Concatenate test output files
           command: |
             # Create artifacts directory
-            mkdir -p ~/test-output-artifacts/
+            mkdir -p /home/circleci/test-output-artifacts/
             
             # Find all module directories that have target/surefire-reports
             for module_dir in */; do
               if [ -d "${module_dir}target/surefire-reports" ]; then
                 module_name=$(basename "${module_dir%/}")
-                output_file="~/test-output-artifacts/${module_name}-test-output.txt"
+                output_file="/home/circleci/test-output-artifacts/${module_name}-test-output.txt"
                 
                 echo "Processing module: ${module_name}"
                 echo "Output file: ${output_file}"
@@ -74,7 +74,7 @@ commands:
             done
           when: always
       - store_artifacts:
-          path: ~/test-output-artifacts
+          path: /home/circleci/test-output-artifacts
           destination: test-output
           when: always
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,54 @@ commands:
       - run:
           name: Run Maven Verify
           command: |
-            mvn -s .circleci/mvn-settings.xml -T4 verify
+            mvn -s .circleci/mvn-settings.xml -T4 --batch-mode verify
       - store_artifacts:
           path: "*/target/site/jacoco/"
+          when: always
+      - store_artifacts:
+          path: "*/target/test-logs/"
+          when: always
+      - run:
+          name: Concatenate test output files
+          command: |
+            # Create artifacts directory
+            mkdir -p ~/test-output-artifacts/
+            
+            # Find all module directories that have target/surefire-reports
+            for module_dir in */; do
+              if [ -d "${module_dir}target/surefire-reports" ]; then
+                module_name=$(basename "${module_dir%/}")
+                output_file="~/test-output-artifacts/${module_name}-test-output.txt"
+                
+                echo "Processing module: ${module_name}"
+                echo "Output file: ${output_file}"
+                
+                # Concatenate all .txt files in the surefire-reports directory
+                if [ -n "$(find "${module_dir}target/surefire-reports" -name "*.txt" -type f)" ]; then
+                  echo "=== Test Output for ${module_name} ===" > "${output_file}"
+                  echo "Generated at: $(date)" >> "${output_file}"
+                  echo "==========================================" >> "${output_file}"
+                  echo "" >> "${output_file}"
+                  
+                  # Sort files to ensure consistent ordering
+                  find "${module_dir}target/surefire-reports" -name "*.txt" -type f | sort | while read -r txt_file; do
+                    echo "--- File: $(basename "${txt_file}") ---" >> "${output_file}"
+                    cat "${txt_file}" >> "${output_file}"
+                    echo "" >> "${output_file}"
+                    echo "--- End of $(basename "${txt_file}") ---" >> "${output_file}"
+                    echo "" >> "${output_file}"
+                  done
+                  
+                  echo "Concatenated test output for ${module_name} to ${output_file}"
+                else
+                  echo "No .txt files found in ${module_dir}target/surefire-reports"
+                fi
+              fi
+            done
+          when: always
+      - store_artifacts:
+          path: ~/test-output-artifacts
+          destination: test-output
           when: always
       - run:
           name: Save test results
@@ -54,8 +99,8 @@ commands:
         - run:
             name: Build and Run ValidateApiVersions
             command: |
-              mvn -s .circleci/mvn-settings.xml -T4 install -DskipTests
-              mvn -s .circleci/mvn-settings.xml -pl qqq-middleware-javalin package appassembler:assemble -DskipTests
+              mvn -s .circleci/mvn-settings.xml -T4 --batch-mode install -DskipTests
+              mvn -s .circleci/mvn-settings.xml -T4 --batch-mode -pl qqq-middleware-javalin package appassembler:assemble -DskipTests
               qqq-middleware-javalin/target/appassembler/bin/ValidateApiVersions -r $(pwd)
 
   mvn_jar_deploy:
@@ -71,7 +116,7 @@ commands:
       - run:
           name: Run Maven Jar Deploy
           command: |
-            mvn -s .circleci/mvn-settings.xml -T4 flatten:flatten jar:jar deploy:deploy
+            mvn -s .circleci/mvn-settings.xml -T4 --batch-mode flatten:flatten jar:jar deploy:deploy
       - save_cache:
           paths:
             - ~/.m2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
             java -version
             echo "Java version check completed"
 
-  mvn_verify:
+  mvn_build:
     steps:
       - checkout
       - restore_cache:
@@ -26,9 +26,24 @@ commands:
           command: |
             echo "RDBMS_PASSWORD=$RDBMS_PASSWORD" >> qqq-sample-project/.env
       - run:
-          name: Run Maven Verify
+          name: Run Maven Compile
           command: |
-            mvn -s .circleci/mvn-settings.xml -T4 --batch-mode verify
+            mvn -s .circleci/mvn-settings.xml -T4 --batch-mode compile
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "pom.xml" }}
+
+  mvn_test:
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "pom.xml" }}
+      - run:
+          name: Run Maven Test
+          command: |
+            mvn -s .circleci/mvn-settings.xml -T4 --batch-mode test
       - store_artifacts:
           path: "*/target/site/jacoco/"
           when: always
@@ -64,6 +79,8 @@ commands:
                     echo "" >> "${output_file}"
                     echo "--- End of $(basename "${txt_file}") ---" >> "${output_file}"
                     echo "" >> "${output_file}"
+                    echo "" >> "${output_file}"
+                    echo "" >> "${output_file}"
                   done
                   
                   echo "Concatenated test output for ${module_name} to ${output_file}"
@@ -85,10 +102,6 @@ commands:
           when: always
       - store_test_results:
           path: ~/test-results
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: v1-dependencies-{{ checksum "pom.xml" }}
 
   check_middleware_api_versions:
       steps:
@@ -148,7 +161,8 @@ jobs:
     steps:
       ## - localstack/startup
       - check_java_version
-      - mvn_verify
+      - mvn_build
+      - mvn_test
       - check_middleware_api_versions
 
   mvn_deploy:
@@ -156,7 +170,8 @@ jobs:
     steps:
       ## - localstack/startup
       - check_java_version
-      - mvn_verify
+      - mvn_build
+      - mvn_test
       - check_middleware_api_versions
       - mvn_jar_deploy
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,64 +20,29 @@ commands:
       - run:
           name: Run Maven Compile
           command: |
-            mvn -s .circleci/mvn-settings.xml -T4 --batch-mode compile
+            mvn -s .circleci/mvn-settings.xml -T4 --no-transfer-progress compile
       - save_cache:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "pom.xml" }}
 
-  mvn_test:
+  mvn_verify:
     steps:
       - checkout
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "pom.xml" }}
       - run:
-          name: Run Maven Test
+          name: Run Maven Verify
           command: |
-            mvn -s .circleci/mvn-settings.xml -T4 --batch-mode test jacoco:report
+            mvn -s .circleci/mvn-settings.xml -T4 --no-transfer-progress verify
       - store_artifacts:
+          name: Store Jacoco reports
           path: "*/target/site/jacoco/"
           when: always
       - run:
           name: Concatenate test output files
-          command: |
-            # Create artifacts directory
-            mkdir -p /home/circleci/test-output-artifacts/
-            
-            # Find all module directories that have target/surefire-reports
-            for module_dir in */; do
-              if [ -d "${module_dir}target/surefire-reports" ]; then
-                module_name=$(basename "${module_dir%/}")
-                output_file="/home/circleci/test-output-artifacts/${module_name}-test-output.txt"
-                
-                echo "Processing module: ${module_name}"
-                echo "Output file: ${output_file}"
-                
-                # Concatenate all .txt files in the surefire-reports directory
-                if [ -n "$(find "${module_dir}target/surefire-reports" -name "*.txt" -type f)" ]; then
-                  echo "=== Test Output for ${module_name} ===" > "${output_file}"
-                  echo "Generated at: $(date)" >> "${output_file}"
-                  echo "==========================================" >> "${output_file}"
-                  echo "" >> "${output_file}"
-                  
-                  # Sort files to ensure consistent ordering
-                  find "${module_dir}target/surefire-reports" -name "*.txt" -type f | sort | while read -r txt_file; do
-                    echo "--- File: $(basename "${txt_file}") ---" >> "${output_file}"
-                    cat "${txt_file}" >> "${output_file}"
-                    echo "" >> "${output_file}"
-                    echo "--- End of $(basename "${txt_file}") ---" >> "${output_file}"
-                    echo "" >> "${output_file}"
-                    echo "" >> "${output_file}"
-                    echo "" >> "${output_file}"
-                  done
-                  
-                  echo "Concatenated test output for ${module_name} to ${output_file}"
-                else
-                  echo "No .txt files found in ${module_dir}target/surefire-reports"
-                fi
-              fi
-            done
+          command: .circleci/concatenate-test-output.sh
           when: always
       - store_artifacts:
           path: /home/circleci/test-output-artifacts
@@ -101,8 +66,8 @@ commands:
         - run:
             name: Build and Run ValidateApiVersions
             command: |
-              mvn -s .circleci/mvn-settings.xml -T4 --batch-mode install -DskipTests
-              mvn -s .circleci/mvn-settings.xml -T4 --batch-mode -pl qqq-middleware-javalin package appassembler:assemble -DskipTests
+              mvn -s .circleci/mvn-settings.xml -T4 --no-transfer-progress install -DskipTests
+              mvn -s .circleci/mvn-settings.xml -T4 --no-transfer-progress -pl qqq-middleware-javalin package appassembler:assemble -DskipTests
               qqq-middleware-javalin/target/appassembler/bin/ValidateApiVersions -r $(pwd)
 
   mvn_jar_deploy:
@@ -118,7 +83,7 @@ commands:
       - run:
           name: Run Maven Jar Deploy
           command: |
-            mvn -s .circleci/mvn-settings.xml -T4 --batch-mode flatten:flatten jar:jar deploy:deploy
+            mvn -s .circleci/mvn-settings.xml -T4 --no-transfer-progress flatten:flatten jar:jar deploy:deploy
       - save_cache:
           paths:
             - ~/.m2
@@ -153,7 +118,7 @@ jobs:
   test:
     executor: localstack/default
     steps:
-      - mvn_test
+      - mvn_verify
 
   api_version_check:
     executor: localstack/default
@@ -164,7 +129,7 @@ jobs:
     executor: localstack/default
     steps:
       - mvn_build
-      - mvn_test
+      - mvn_verify
       - check_middleware_api_versions
       - mvn_jar_deploy
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ There are a few useful IntelliJ settings files, under `qqq-dev-tools/intellij`:
 One will likely also want the [Kingsrook Commentator
 Plugin](https://plugins.jetbrains.com/plugin/19325-kingsrook-commentator).
 
+## Test Logging
+By default, when ran from the command line, mvn surefire will make each test's
+output (e.g., System.out, err, printStackTrace, and all logger calls) go into a 
+file under target/surefire-reports/${className}.txt. 
+
+The system property `-DtestOutputToFile=false` can be given on the command line
+to get all of this output on the console.
+
+In the IDE (e.g,. IntelliJ), output goes to the Console.
+
+In CircleCI, output goes to files, and those files are concatenated together and 
+stored as artifacts.
+
+
 ## License
 QQQ - Low-code Application Framework for Engineers. \
 Copyright (C) 2020-2024.  Kingsrook, LLC \

--- a/pom.xml
+++ b/pom.xml
@@ -249,25 +249,25 @@ echo "   See also target/site/jacoco/index.html"
 echo "   and https://www.jacoco.org/jacoco/trunk/doc/counters.html"
 echo "------------------------------------------------------------"
 
-if which xpath > /dev/null 2>&1; then
+# Parse Jacoco HTML coverage summary using grep and sed
+if [ -f target/site/jacoco/index.html ]; then
    echo "Element\nInstructions Missed\nInstruction Coverage\nBranches Missed\nBranch Coverage\nComplexity Missed\nComplexity Hit\nLines Missed\nLines Hit\nMethods Missed\nMethods Hit\nClasses Missed\nClasses Hit\n" > /tmp/$$.headers
-   xpath -n -q -e '/html/body/table/tfoot/tr[1]/td/text()' target/site/jacoco/index.html > /tmp/$$.values
+   # Extract values from the footer row of the coverage table
+   grep -A 12 '<tfoot>' target/site/jacoco/index.html | grep '<td>' | sed 's/<td>\([^<]*\)<\/td>/\1/' | tr '\n' '\t' | sed 's/\t$/\n/' > /tmp/$$.values
    paste /tmp/$$.headers /tmp/$$.values | tail +2 | awk -v FS='\t' '{printf("%-20s %s\n",$1,$2)}'
    rm /tmp/$$.headers /tmp/$$.values
 else
-   echo "xpath is not installed.  Jacoco coverage summary will not be produced here...";
+   echo "Jacoco coverage summary could not be parsed...";
 fi
 
-if which html2text > /dev/null 2>&1; then
-   echo "Untested classes, per Jacoco:"
-   echo "-----------------------------"
-   for i in target/site/jacoco/*/index.html; do
-      html2text -width 500 -nobs $i | sed '1,/^Total/d;' | grep -v Created | sed 's/ \+/ /g' | sed 's/ [[:digit:]]$//' | grep -v 0$ | cut -d' ' -f1;
-   done;
-   echo
-else
-   echo "html2text is not installed.  Untested classes from Jacoco will not be printed here...";
-fi
+echo "Untested classes, per Jacoco:"
+echo "-----------------------------"
+# Parse Jacoco XML reports directly to find classes with 0% coverage
+find target/site/jacoco -name "jacoco.xml" -exec grep -l '<counter type="LINE" missed="[1-9]' {} \; | while read xmlfile; do
+   # Extract class names from XML files that have missed lines
+   grep -A 1 '<class name=' "$xmlfile" | grep -B 1 '<counter type="LINE" missed="[1-9]' | grep '<class name=' | sed 's/.*name="\([^"]*\)".*/\1/' | sort -u
+done | sort -u
+echo
 
                            ]]>
                         </argument>

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@ if [ ! -e target/site/jacoco/index.html ]; then
 fi
 
 echo
-echo "Jacoco coverage summary report:"
+echo "Jacoco coverage summary report for module: ${project.artifactId}"
 echo "   See also target/site/jacoco/index.html"
 echo "   and https://www.jacoco.org/jacoco/trunk/doc/counters.html"
 echo "------------------------------------------------------------"
@@ -261,11 +261,14 @@ if [ -f target/site/jacoco/index.html ]; then
 else
    echo "Jacoco coverage summary was not found.";
 fi
+echo "-----------------------------"
+echo
 
-echo "Untested classes, per Jacoco:"
+echo "Untested classes, per Jacoco for module: ${project.artifactId}"
 echo "-----------------------------"
 # Parse Jacoco XML reports directly to find classes with 0% coverage
 sed 's/<classs .*\?>/&\n/g;s/<\/class>/&\n/g' target/site/jacoco/jacoco.xml | grep -v 'counter type="CLASS" missed="0"' | sed 's/>.*//;s/.*\///;s/".*//'
+echo "-----------------------------"
 echo
 
                            ]]>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
       <coverage.instructionCoveredRatioMinimum>0.80</coverage.instructionCoveredRatioMinimum>
       <coverage.classCoveredRatioMinimum>0.95</coverage.classCoveredRatioMinimum>
       <plugin.shade.phase>none</plugin.shade.phase>
+      <testOutputToFile>true</testOutputToFile>
    </properties>
 
    <profiles>
@@ -141,6 +142,8 @@
             <configuration>
                <!-- Sets the VM argument line used when integration tests are run. -->
                <argLine>@{jaCoCoArgLine}</argLine>
+               <!-- Reduce console output for cleaner JUnit output -->
+               <redirectTestOutputToFile>${testOutputToFile}</redirectTestOutputToFile>
             </configuration>
          </plugin>
          <plugin>
@@ -249,10 +252,9 @@ echo "   See also target/site/jacoco/index.html"
 echo "   and https://www.jacoco.org/jacoco/trunk/doc/counters.html"
 echo "------------------------------------------------------------"
 
-# Parse Jacoco HTML coverage summary using grep and sed
+# Parse Jacoco HTML coverage summary 
 if [ -f target/site/jacoco/index.html ]; then
-   echo -e "Instructions Missed\nInstruction Coverage\nBranches Missed\nBranch Coverage\nComplexity Missed\nComplexity Hit\nLines Missed\nLines Hit\nMethods Missed\nMethods Hit\nClasses Missed\nClasses Hit\n" > /tmp/$$headers
-   # Extract values from the footer row of the coverage table
+   echo -e "Instructions Missed\nInstruction Coverage\nBranches Missed\nBranch Coverage\nComplexity Missed\nComplexity Hit\nLines Missed\nLines Hit\nMethods Missed\nMethods Hit\nClasses Missed\nClasses Hit\n" > /tmp/$$.headers
    sed 's/<\/\w\+>/&\n/g' target/site/jacoco/index.html | grep -A 12 '<tfoot>' | grep '<td' | sed 's/<td class="\w\+\d*">\([^<]*\)<\/td>/\1/' | grep -v Total > /tmp/$$.values
    paste /tmp/$$.headers /tmp/$$.values | tail +2 | awk -v FS='\t' '{printf("%-20s %s\n",$1,$2)}'
    rm /tmp/$$.headers /tmp/$$.values

--- a/pom.xml
+++ b/pom.xml
@@ -251,22 +251,19 @@ echo "------------------------------------------------------------"
 
 # Parse Jacoco HTML coverage summary using grep and sed
 if [ -f target/site/jacoco/index.html ]; then
-   echo "Element\nInstructions Missed\nInstruction Coverage\nBranches Missed\nBranch Coverage\nComplexity Missed\nComplexity Hit\nLines Missed\nLines Hit\nMethods Missed\nMethods Hit\nClasses Missed\nClasses Hit\n" > /tmp/$$.headers
+   echo -e "Instructions Missed\nInstruction Coverage\nBranches Missed\nBranch Coverage\nComplexity Missed\nComplexity Hit\nLines Missed\nLines Hit\nMethods Missed\nMethods Hit\nClasses Missed\nClasses Hit\n" > /tmp/$$headers
    # Extract values from the footer row of the coverage table
-   grep -A 12 '<tfoot>' target/site/jacoco/index.html | grep '<td>' | sed 's/<td>\([^<]*\)<\/td>/\1/' | tr '\n' '\t' | sed 's/\t$/\n/' > /tmp/$$.values
+   sed 's/<\/\w\+>/&\n/g' target/site/jacoco/index.html | grep -A 12 '<tfoot>' | grep '<td' | sed 's/<td class="\w\+\d*">\([^<]*\)<\/td>/\1/' | grep -v Total > /tmp/$$.values
    paste /tmp/$$.headers /tmp/$$.values | tail +2 | awk -v FS='\t' '{printf("%-20s %s\n",$1,$2)}'
    rm /tmp/$$.headers /tmp/$$.values
 else
-   echo "Jacoco coverage summary could not be parsed...";
+   echo "Jacoco coverage summary was not found.";
 fi
 
 echo "Untested classes, per Jacoco:"
 echo "-----------------------------"
 # Parse Jacoco XML reports directly to find classes with 0% coverage
-find target/site/jacoco -name "jacoco.xml" -exec grep -l '<counter type="LINE" missed="[1-9]' {} \; | while read xmlfile; do
-   # Extract class names from XML files that have missed lines
-   grep -A 1 '<class name=' "$xmlfile" | grep -B 1 '<counter type="LINE" missed="[1-9]' | grep '<class name=' | sed 's/.*name="\([^"]*\)".*/\1/' | sort -u
-done | sort -u
+sed 's/<classs .*\?>/&\n/g;s/<\/class>/&\n/g' target/site/jacoco/jacoco.xml | grep -v 'counter type="CLASS" missed="0"' | sed 's/>.*//;s/.*\///;s/".*//'
 echo
 
                            ]]>


### PR DESCRIPTION
major rewrite of circleci config (mostly done by cursor).  Highlights:
- by default, mvn builds will now not output all System.out, err, logs, and stack traces (though runs in the IDE still will, and it can be opted in to via -DtestOutputToFile=false)
- in circleci, the test output files get concatted together and uploaded as artifacts, if they need reviewed.
- fixed jacoco summary stats & uncovered class reporting in circleci, w/o any external deps (e.g., to speed up builds)
- removed an explicit install of java17, since our executor already had it (!) - should speed up build ~a minute
- updated to mvn build in one step, so its loud output is segregated from test outputs (which are more useful now that it's just junit reporting success/fail, not all logs from our code)
- update to run check-middleware-api-versions in parallel with mvn verify, in theory should speed up some too.
