### PR TITLE
Update QProcessCallback with new method customizeInputPreQuery - then…

### DIFF
--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/processes/QProcessCallback.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/processes/QProcessCallback.java
@@ -25,7 +25,9 @@ package com.kingsrook.qqq.backend.core.actions.processes;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import com.kingsrook.qqq.backend.core.model.actions.processes.RunBackendStepInput;
 import com.kingsrook.qqq.backend.core.model.actions.tables.query.QQueryFilter;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.QueryInput;
 import com.kingsrook.qqq.backend.core.model.metadata.fields.QFieldMetaData;
 
 
@@ -50,5 +52,16 @@ public interface QProcessCallback
    default Map<String, Serializable> getFieldValues(List<QFieldMetaData> fields)
    {
       return (null);
+   }
+
+   /***************************************************************************
+    * Allow a callback to modify the query input that a process uses to find its
+    * initial records (e.g., to add a transaction or turn on heavy fields).
+    ***************************************************************************/
+   default void customizeInputPreQuery(RunBackendStepInput runBackendStepInput, QueryInput queryInput)
+   {
+      /////////////////////
+      // noop by default //
+      /////////////////////
    }
 }

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/processes/QProcessCallbackBuilder.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/processes/QProcessCallbackBuilder.java
@@ -1,0 +1,256 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2024.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.actions.processes;
+
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import com.kingsrook.qqq.backend.core.context.QContext;
+import com.kingsrook.qqq.backend.core.exceptions.QRuntimeException;
+import com.kingsrook.qqq.backend.core.model.actions.processes.RunBackendStepInput;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.QCriteriaOperator;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.QFilterCriteria;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.QQueryFilter;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.QueryInput;
+import com.kingsrook.qqq.backend.core.model.data.QRecord;
+import com.kingsrook.qqq.backend.core.model.data.QRecordEntity;
+import com.kingsrook.qqq.backend.core.model.metadata.fields.QFieldMetaData;
+import com.kingsrook.qqq.backend.core.utils.StringUtils;
+
+
+/*******************************************************************************
+ ** Builder pattern for creating a QProcessCallback
+ *******************************************************************************/
+public class QProcessCallbackBuilder
+{
+   private QQueryFilter                                filter;
+   private BiConsumer<RunBackendStepInput, QueryInput> queryInputCustomizer;
+   private Map<String, Serializable>                   fieldValues;
+
+
+
+   /*******************************************************************************
+    * Construct the callback object from the builder.
+    *******************************************************************************/
+   public QProcessCallback build()
+   {
+      return new QProcessCallback()
+      {
+         /*******************************************************************************
+          **
+          *******************************************************************************/
+         @Override
+         public QQueryFilter getQueryFilter()
+         {
+            return (filter);
+         }
+
+
+
+         /*******************************************************************************
+          **
+          *******************************************************************************/
+         @Override
+         public Map<String, Serializable> getFieldValues(List<QFieldMetaData> fields)
+         {
+            return (fieldValues);
+         }
+
+
+
+         /***************************************************************************
+          *
+          ***************************************************************************/
+         @Override
+         public void customizeInputPreQuery(RunBackendStepInput runBackendStepInput, QueryInput queryInput)
+         {
+            if(queryInputCustomizer != null)
+            {
+               queryInputCustomizer.accept(runBackendStepInput, queryInput);
+            }
+         }
+      };
+   }
+
+
+
+   /*******************************************************************************
+    * build a callback whose filter will return a single record
+    * @param entity the record you want returned
+    *******************************************************************************/
+   public QProcessCallbackBuilder withRecordEntity(QRecordEntity entity)
+   {
+      return withRecord(entity.toQRecord());
+   }
+
+
+
+   /*******************************************************************************
+    * build a callback whose filter will return a single record
+    * @param record the record you want returned
+    *******************************************************************************/
+   public QProcessCallbackBuilder withRecord(QRecord record)
+   {
+      String primaryKeyField = "id";
+      if(StringUtils.hasContent(record.getTableName()))
+      {
+         primaryKeyField = QContext.getQInstance().getTable(record.getTableName()).getPrimaryKeyField();
+      }
+
+      Serializable primaryKeyValue = record.getValue(primaryKeyField);
+      if(primaryKeyValue == null)
+      {
+         throw (new QRuntimeException("Record did not have value in its primary key field [" + primaryKeyField + "]"));
+      }
+
+      return (withPrimaryKey(primaryKeyField, primaryKeyValue));
+   }
+
+
+
+   /*******************************************************************************
+    * build a callback whose filter will execute fieldName = value query
+    * @param fieldName to be queried for
+    * @param value to be queried for
+    *******************************************************************************/
+   public QProcessCallbackBuilder withPrimaryKey(String fieldName, Serializable value)
+   {
+      this.filter = new QQueryFilter().withCriteria(new QFilterCriteria(fieldName, QCriteriaOperator.EQUALS, value));
+      return this;
+   }
+
+
+
+   /*******************************************************************************
+    * build a callback whose filter will execute fieldName IN values query
+    * @param fieldName to be queried for
+    * @param values to be queried for (IN)
+    *******************************************************************************/
+   public QProcessCallbackBuilder withPrimaryKeys(String fieldName, Collection<? extends Serializable> values)
+   {
+      this.filter = new QQueryFilter().withCriteria(new QFilterCriteria(fieldName, QCriteriaOperator.IN, values));
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for queryInputCustomizer
+    * @see #withQueryInputCustomizer(BiConsumer)
+    *******************************************************************************/
+   public BiConsumer<RunBackendStepInput, QueryInput> getQueryInputCustomizer()
+   {
+      return (this.queryInputCustomizer);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for queryInputCustomizer
+    * @see #withQueryInputCustomizer(BiConsumer)
+    *******************************************************************************/
+   public void setQueryInputCustomizer(BiConsumer<RunBackendStepInput, QueryInput> queryInputCustomizer)
+   {
+      this.queryInputCustomizer = queryInputCustomizer;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for queryInputCustomizer
+    *
+    * @param queryInputCustomizer
+    * lambda that will be placed in the Callback object and used in its
+    * customizeInputPreQuery method.
+    * @return this
+    *******************************************************************************/
+   public QProcessCallbackBuilder withQueryInputCustomizer(BiConsumer<RunBackendStepInput, QueryInput> queryInputCustomizer)
+   {
+      this.queryInputCustomizer = queryInputCustomizer;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for fieldValues
+    * @see #withFieldValues(Map)
+    *******************************************************************************/
+   public void setFieldValues(Map<String, Serializable> fieldValues)
+   {
+      this.fieldValues = fieldValues;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for fieldValues
+    *
+    * @param fieldValues will be returned in the callback
+    * @return this
+    *******************************************************************************/
+   public QProcessCallbackBuilder withFieldValues(Map<String, Serializable> fieldValues)
+   {
+      this.fieldValues = fieldValues;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for filter
+    * @see #withFilter(QQueryFilter)
+    *******************************************************************************/
+   public QQueryFilter getFilter()
+   {
+      return (this.filter);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for filter
+    * @see #withFilter(QQueryFilter)
+    *******************************************************************************/
+   public void setFilter(QQueryFilter filter)
+   {
+      this.filter = filter;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for filter
+    *
+    * @param filter to be returned by the callback
+    * @return this
+    *******************************************************************************/
+   public QProcessCallbackBuilder withFilter(QQueryFilter filter)
+   {
+      this.filter = filter;
+      return (this);
+   }
+
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/processes/RunBackendStepAction.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/processes/RunBackendStepAction.java
@@ -240,6 +240,14 @@ public class RunBackendStepAction
                queryInput.getFilter().setLimit(process.getMaxInputRecords() + 1);
             }
 
+            /////////////////////////////////////////////////////////////////////////////////
+            // allow callback to customize the query input just here before the query runs //
+            /////////////////////////////////////////////////////////////////////////////////
+            if(runBackendStepInput.getCallback() != null)
+            {
+               runBackendStepInput.getCallback().customizeInputPreQuery(runBackendStepInput, queryInput);
+            }
+
             QueryOutput queryOutput = new QueryAction().execute(queryInput);
             runBackendStepInput.setRecords(queryOutput.getRecords());
 

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/processes/implementations/etl/streamedwithfrontend/ExtractViaQueryStep.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/processes/implementations/etl/streamedwithfrontend/ExtractViaQueryStep.java
@@ -130,7 +130,7 @@ public class ExtractViaQueryStep extends AbstractExtractStep
          queryInput.setIncludeAssociations(true);
       }
 
-      customizeInputPreQuery(queryInput);
+      customizeInputPreQuery(runBackendStepInput, queryInput);
 
       new QueryAction().execute(queryInput);
 
@@ -144,9 +144,24 @@ public class ExtractViaQueryStep extends AbstractExtractStep
    /*******************************************************************************
     ** chance for sub-classes to change things about the query input, if they want.
     *******************************************************************************/
+   protected void customizeInputPreQuery(RunBackendStepInput runBackendStepInput, QueryInput queryInput)
+   {
+      customizeInputPreQuery(queryInput);
+
+      if(runBackendStepInput.getCallback() != null)
+      {
+         runBackendStepInput.getCallback().customizeInputPreQuery(runBackendStepInput, queryInput);
+      }
+   }
+
+
+
+   /*******************************************************************************
+    ** chance for sub-classes to change things about the query input, if they want.
+    *******************************************************************************/
+   @Deprecated(since = "Overload that takes RunBackendStepInput was added in 0.26")
    protected void customizeInputPreQuery(QueryInput queryInput)
    {
-
    }
 
 

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/processes/implementations/garbagecollector/GarbageCollectorExtractStep.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/processes/implementations/garbagecollector/GarbageCollectorExtractStep.java
@@ -61,11 +61,11 @@ public class GarbageCollectorExtractStep extends ExtractViaQueryStep
 
 
 
-   /*******************************************************************************
-    **
-    *******************************************************************************/
+   /***************************************************************************
+    *
+    ***************************************************************************/
    @Override
-   protected void customizeInputPreQuery(QueryInput queryInput)
+   protected void customizeInputPreQuery(RunBackendStepInput runBackendStepInput, QueryInput queryInput)
    {
       queryInput.withQueryHint(QueryHint.POTENTIALLY_LARGE_NUMBER_OF_RESULTS);
    }

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/processes/implementations/scripts/RunRecordScriptExtractStep.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/processes/implementations/scripts/RunRecordScriptExtractStep.java
@@ -77,9 +77,9 @@ public class RunRecordScriptExtractStep extends ExtractViaQueryStep
     ** Make sure associations are fetched (so api records have children!)
     *******************************************************************************/
    @Override
-   protected void customizeInputPreQuery(QueryInput queryInput)
+   protected void customizeInputPreQuery(RunBackendStepInput runBackendStepInput, QueryInput queryInput)
    {
-      super.customizeInputPreQuery(queryInput);
+      super.customizeInputPreQuery(runBackendStepInput, queryInput);
       queryInput.setIncludeAssociations(true);
    }
 

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/processes/implementations/etl/streamedwithfrontend/ExtractViaQueryStepTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/processes/implementations/etl/streamedwithfrontend/ExtractViaQueryStepTest.java
@@ -1,0 +1,74 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2025.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.processes.implementations.etl.streamedwithfrontend;
+
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import com.kingsrook.qqq.backend.core.BaseTest;
+import com.kingsrook.qqq.backend.core.actions.processes.QProcessCallback;
+import com.kingsrook.qqq.backend.core.exceptions.QException;
+import com.kingsrook.qqq.backend.core.model.actions.processes.RunBackendStepInput;
+import com.kingsrook.qqq.backend.core.model.actions.processes.RunBackendStepOutput;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.QueryInput;
+import com.kingsrook.qqq.backend.core.utils.TestUtils;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/*******************************************************************************
+ ** Unit test for ExtractViaQueryStep 
+ *******************************************************************************/
+class ExtractViaQueryStepTest extends BaseTest
+{
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testCustomizeInputPreQuery() throws QException
+   {
+      AtomicBoolean called = new AtomicBoolean(false);
+
+      RunBackendStepInput input = new RunBackendStepInput();
+      input.addValue(StreamedETLWithFrontendProcess.FIELD_SOURCE_TABLE, TestUtils.TABLE_NAME_PERSON_MEMORY);
+      input.addValue(StreamedETLWithFrontendProcess.FIELD_DEFAULT_QUERY_FILTER, "{}");
+      input.setCallback(new QProcessCallback()
+      {
+         /***************************************************************************
+          *
+          ***************************************************************************/
+         @Override
+         public void customizeInputPreQuery(RunBackendStepInput runBackendStepInput, QueryInput queryInput)
+         {
+            called.set(true);
+         }
+      });
+
+      RunBackendStepOutput output = new RunBackendStepOutput();
+      ExtractViaQueryStep  extractViaQueryStep = new ExtractViaQueryStep();
+      extractViaQueryStep.preRun(input, output);
+      extractViaQueryStep.run(input, output);
+
+      assertTrue(called.get());
+   }
+}


### PR DESCRIPTION
…, use that method to get the open transaction into the process ran by BaseSyncToScheduledJobTableCustomizer - so it can see, e.g., records being bulk inserted or updated.

While doing this, also overload customizeInputPreQuery in ExtractViaQueryStep, to take the RunBackendStepInput as an additional param (and deprecate the version that just took queryInput (and update places that the now-deprecated method was called)).