### PR TITLE
Make unique key checks on tables which are a cacheOf another table NO…

### DIFF
--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/tables/helpers/QueryActionCacheHelper.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/tables/helpers/QueryActionCacheHelper.java
@@ -41,6 +41,7 @@ import com.kingsrook.qqq.backend.core.actions.tables.UpdateAction;
 import com.kingsrook.qqq.backend.core.context.QContext;
 import com.kingsrook.qqq.backend.core.exceptions.QException;
 import com.kingsrook.qqq.backend.core.logging.QLogger;
+import com.kingsrook.qqq.backend.core.model.actions.tables.ActionFlag;
 import com.kingsrook.qqq.backend.core.model.actions.tables.QueryOrGetInputInterface;
 import com.kingsrook.qqq.backend.core.model.actions.tables.delete.DeleteInput;
 import com.kingsrook.qqq.backend.core.model.actions.tables.get.GetInput;
@@ -89,11 +90,35 @@ public class QueryActionCacheHelper
 
 
 
+   /***************************************************************************
+    * action flags that can be put in a query request to control behavior in
+    * this class.
+    ***************************************************************************/
+   public enum CacheActionFlags implements ActionFlag
+   {
+      /***************************************************************************
+       * Cause the handleCaching method to basically noop - but the intent is, that
+       * it doesn't every query the source table (the one behind the cache).
+       ***************************************************************************/
+      DO_NOT_QUERY_SOURCE_TABLE
+   }
+
+
+
    /*******************************************************************************
     **
     *******************************************************************************/
    public void handleCaching(QueryInput queryInput, QueryOutput queryOutput) throws QException
    {
+      if(queryInput.hasFlag(CacheActionFlags.DO_NOT_QUERY_SOURCE_TABLE))
+      {
+         //////////////////////////////////////////////////////////////////////////////////////////
+         // if the caller is requesting that we not query the source table under any conditions, //
+         // (e.g., unique key checks) then there's nothing to do in this method, so return early //
+         //////////////////////////////////////////////////////////////////////////////////////////
+         return;
+      }
+
       analyzeInput(queryInput);
       if(!isQueryInputCacheable)
       {

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/tables/helpers/UniqueKeyHelper.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/tables/helpers/UniqueKeyHelper.java
@@ -118,6 +118,14 @@ public class UniqueKeyHelper
             }
 
             queryInput.setFilter(filter);
+
+            /////////////////////////////////////////////////////////////////////////////////////////
+            // in case the table we're working with is a CacheOf - tell the QueryActionCacheHelper //
+            // not to do queries on the table behind the cache table (e.g., for cache misses or    //
+            // expired records).  we just want to look at the cache table itself.                  //
+            /////////////////////////////////////////////////////////////////////////////////////////
+            queryInput.withFlag(QueryActionCacheHelper.CacheActionFlags.DO_NOT_QUERY_SOURCE_TABLE);
+
             QueryOutput queryOutput = new QueryAction().execute(queryInput);
             for(QRecord record : queryOutput.getRecords())
             {

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/QueryInput.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/QueryInput.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import com.kingsrook.qqq.backend.core.actions.QBackendTransaction;
 import com.kingsrook.qqq.backend.core.actions.reporting.RecordPipe;
 import com.kingsrook.qqq.backend.core.model.actions.AbstractTableActionInput;
+import com.kingsrook.qqq.backend.core.model.actions.tables.ActionFlag;
 import com.kingsrook.qqq.backend.core.model.actions.tables.QueryHint;
 import com.kingsrook.qqq.backend.core.model.actions.tables.QueryOrCountInputInterface;
 import com.kingsrook.qqq.backend.core.model.actions.tables.QueryOrGetInputInterface;
@@ -84,6 +85,7 @@ public class QueryInput extends AbstractTableActionInput implements QueryOrGetIn
    private Collection<String> associationNamesToInclude = null;
 
    private EnumSet<QueryHint> queryHints = EnumSet.noneOf(QueryHint.class);
+   private Set<ActionFlag>    flags;
 
 
 
@@ -724,6 +726,75 @@ public class QueryInput extends AbstractTableActionInput implements QueryOrGetIn
    {
       this.fieldNamesToInclude = fieldNamesToInclude;
       return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for flags
+    * @see #withFlags(Set)
+    *******************************************************************************/
+   public Set<ActionFlag> getFlags()
+   {
+      return (this.flags);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for flags
+    * @see #withFlags(Set)
+    *******************************************************************************/
+   public void setFlags(Set<ActionFlag> flags)
+   {
+      this.flags = flags;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for flags
+    *
+    * @param flags
+    * framework, backend-module, or application defined flags that con be used to drive
+    * behaviors.  For example, maybe to bypass caching actions, or to customize a
+    * query, etc.
+    * @return this
+    *******************************************************************************/
+   public QueryInput withFlags(Set<ActionFlag> flags)
+   {
+      this.flags = flags;
+      return (this);
+   }
+
+
+
+   /***************************************************************************
+    **
+    ***************************************************************************/
+   public QueryInput withFlag(ActionFlag flag)
+   {
+      if(this.flags == null)
+      {
+         this.flags = new HashSet<>();
+      }
+      this.flags.add(flag);
+      return (this);
+   }
+
+
+
+   /***************************************************************************
+    **
+    ***************************************************************************/
+   public boolean hasFlag(ActionFlag flag)
+   {
+      if(this.flags == null)
+      {
+         return (false);
+      }
+
+      return (this.flags.contains(flag));
    }
 
 }


### PR DESCRIPTION
…T look for the UK values in the source table (which then leads to creating cached records, and defeating the purpose of the UK lookup).  This should allow tables which are a cacheOf other tables to be directly inserted into in application code.