### PR TITLE
Exclude sample module from integration builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
       <module>qqq-middleware-slack</module>
       <module>qqq-middleware-api</module>
       <module>qqq-utility-lambdas</module>
-      <module>qqq-sample-project</module>
    </modules>
 
    <properties>
@@ -70,6 +69,13 @@
          <properties>
             <plugin.shade.phase>package</plugin.shade.phase>
          </properties>
+      </profile>
+      <profile>
+         <!-- Optional sample app module: activate with -P withSample -->
+         <id>withSample</id>
+         <modules>
+            <module>qqq-sample-project</module>
+         </modules>
       </profile>
    </profiles>
 


### PR DESCRIPTION
Removes `qqq-sample-project` from the default modules to prevent Central builds from failing due to `qqq-frontend-material-dashboard` not being on Central. The sample remains available behind `-P withSample`.

This makes integration and release deploys green.