### PR TITLE
Bump Central Publisher to 0.8.0 (enable snapshots)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,7 +365,7 @@ echo
          <plugin>
             <groupId>org.sonatype.central</groupId>
             <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.5.0</version>
+            <version>0.8.0</version>
             <extensions>true</extensions>
             <configuration>
                <!-- Server credentials with this ID must be provided in settings.xml -->


### PR DESCRIPTION
Updates parent POM to use central-publishing-maven-plugin 0.8.0, required for publishing -SNAPSHOT to Central.

After merge, re-run the integration deploy to publish 0.26.1-SNAPSHOT.