### PR TITLE
Restore release profile to integration POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,65 @@
          </properties>
       </profile>
       <profile>
+         <!-- Release profile for Maven Central: attach sources/javadocs and sign artifacts -->
+         <id>release</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-source-plugin</artifactId>
+                  <version>3.3.0</version>
+                  <executions>
+                     <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                           <goal>jar</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+               </plugin>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-javadoc-plugin</artifactId>
+                  <version>3.6.2</version>
+                  <configuration>
+                     <failOnError>false</failOnError>
+                     <doclint>none</doclint>
+                  </configuration>
+                  <executions>
+                     <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                           <goal>jar</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+               </plugin>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-gpg-plugin</artifactId>
+                  <version>3.2.4</version>
+                  <configuration>
+                     <keyname>${gpg.keyname}</keyname>
+                     <gpgArguments>
+                        <arg>--pinentry-mode</arg>
+                        <arg>loopback</arg>
+                     </gpgArguments>
+                  </configuration>
+                  <executions>
+                     <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                           <goal>sign</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+      <profile>
          <!-- Optional sample app module: activate with -P withSample -->
          <id>withSample</id>
          <modules>


### PR DESCRIPTION
Adds the 'release' profile back (sources/javadocs + GPG signing) so CircleCI's mvn -P release deploy works. Central plugin remains at 0.8.0. After merge, re-run integration deploy.