### PR TITLE
CI: skip signing for SNAPSHOT deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,8 +96,13 @@ commands:
       - run:
           name: Publish to Sonatype Central (releases and SNAPSHOTs)
           command: |
-            mvn -s .circleci/mvn-settings.xml -P release -B -T4 --no-transfer-progress -DskipTests \
-              -Dgpg.keyname="$GPG_KEYNAME" -Dgpg.passphrase="$GPG_PASSPHRASE" deploy
+            # Skip signing for SNAPSHOT to avoid pinentry/passphrase issues
+            if grep -q -- "-SNAPSHOT</revision>" pom.xml; then
+              SIGN_FLAGS="-Dgpg.skip=true"
+            else
+              SIGN_FLAGS="-Dgpg.keyname=\"$GPG_KEYNAME\" -Dgpg.passphrase=\"$GPG_PASSPHRASE\""
+            fi
+            mvn -s .circleci/mvn-settings.xml -P release -B -T4 --no-transfer-progress -DskipTests $SIGN_FLAGS deploy
       - save_cache:
           paths:
             - ~/.m2


### PR DESCRIPTION
Avoids maven-gpg-plugin failures on integration (SNAPSHOT), while still signing releases. Central plugin 0.8.0 handles snapshots without signing.