### PR TITLE
feat(audit): support non-integer primary keys in audit system

### DIFF
--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/audits/AuditAction.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/audits/AuditAction.java
@@ -78,7 +78,7 @@ public class AuditAction extends AbstractQActionFunction<AuditInput, AuditOutput
    /*******************************************************************************
     ** Execute to insert 1 audit, with no details (child records)
     *******************************************************************************/
-   public static void execute(String tableName, Integer recordId, Map<String, Serializable> securityKeyValues, String message)
+   public static void execute(String tableName, Serializable recordId, Map<String, Serializable> securityKeyValues, String message)
    {
       execute(tableName, recordId, securityKeyValues, message, null);
    }
@@ -88,7 +88,7 @@ public class AuditAction extends AbstractQActionFunction<AuditInput, AuditOutput
    /*******************************************************************************
     ** Execute to insert 1 audit, with a list of detail child records provided as just string messages
     *******************************************************************************/
-   public static void executeWithStringDetails(String tableName, Integer recordId, Map<String, Serializable> securityKeyValues, String message, List<String> detailMessages)
+   public static void executeWithStringDetails(String tableName, Serializable recordId, Map<String, Serializable> securityKeyValues, String message, List<String> detailMessages)
    {
       List<QRecord> detailRecords = null;
       if(CollectionUtils.nullSafeHasContents(detailMessages))
@@ -103,7 +103,7 @@ public class AuditAction extends AbstractQActionFunction<AuditInput, AuditOutput
    /*******************************************************************************
     ** Execute to insert 1 audit, with a list of detail child records
     *******************************************************************************/
-   public static void execute(String tableName, Integer recordId, Map<String, Serializable> securityKeyValues, String message, List<QRecord> details)
+   public static void execute(String tableName, Serializable recordId, Map<String, Serializable> securityKeyValues, String message, List<QRecord> details)
    {
       new AuditAction().execute(new AuditInput().withAuditSingleInput(new AuditSingleInput()
          .withAuditTableName(tableName)
@@ -125,7 +125,7 @@ public class AuditAction extends AbstractQActionFunction<AuditInput, AuditOutput
     *******************************************************************************/
    public static void appendToInput(AuditInput auditInput, QTableMetaData table, QRecord record, String auditMessage)
    {
-      appendToInput(auditInput, table.getName(), record.getValueInteger(table.getPrimaryKeyField()), getRecordSecurityKeyValues(table, record, Optional.empty()), auditMessage);
+      appendToInput(auditInput, table.getName(), record.getValue(table.getPrimaryKeyField()), getRecordSecurityKeyValues(table, record, Optional.empty()), auditMessage);
    }
 
 
@@ -133,7 +133,7 @@ public class AuditAction extends AbstractQActionFunction<AuditInput, AuditOutput
    /*******************************************************************************
     ** Add 1 auditSingleInput to an AuditInput object - with no details (child records).
     *******************************************************************************/
-   public static void appendToInput(AuditInput auditInput, String tableName, Integer recordId, Map<String, Serializable> securityKeyValues, String message)
+   public static void appendToInput(AuditInput auditInput, String tableName, Serializable recordId, Map<String, Serializable> securityKeyValues, String message)
    {
       appendToInput(auditInput, tableName, recordId, securityKeyValues, message, null);
    }
@@ -143,7 +143,7 @@ public class AuditAction extends AbstractQActionFunction<AuditInput, AuditOutput
    /*******************************************************************************
     ** Add 1 auditSingleInput to an AuditInput object - with a list of details (child records).
     *******************************************************************************/
-   public static AuditInput appendToInput(AuditInput auditInput, String tableName, Integer recordId, Map<String, Serializable> securityKeyValues, String message, List<QRecord> details)
+   public static AuditInput appendToInput(AuditInput auditInput, String tableName, Serializable recordId, Map<String, Serializable> securityKeyValues, String message, List<QRecord> details)
    {
       if(auditInput == null)
       {

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/audits/AuditSingleInput.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/audits/AuditSingleInput.java
@@ -43,11 +43,11 @@ import com.kingsrook.qqq.backend.core.utils.CollectionUtils;
  *******************************************************************************/
 public class AuditSingleInput implements Serializable
 {
-   private String  auditTableName;
-   private String  auditUserName;
-   private Instant timestamp;
-   private String  message;
-   private Integer recordId;
+   private String       auditTableName;
+   private String       auditUserName;
+   private Instant      timestamp;
+   private String       message;
+   private Serializable recordId;
 
    private Map<String, Serializable> securityKeyValues;
 
@@ -72,7 +72,7 @@ public class AuditSingleInput implements Serializable
    public AuditSingleInput(QTableMetaData table, QRecord record, String auditMessage)
    {
       setAuditTableName(table.getName());
-      setRecordId(record.getValueInteger(table.getPrimaryKeyField()));
+      setRecordId(record.getValue(table.getPrimaryKeyField()));
       setSecurityKeyValues(AuditAction.getRecordSecurityKeyValues(table, record, Optional.empty()));
       setMessage(auditMessage);
    }
@@ -248,7 +248,7 @@ public class AuditSingleInput implements Serializable
    /*******************************************************************************
     ** Getter for recordId
     *******************************************************************************/
-   public Integer getRecordId()
+   public Serializable getRecordId()
    {
       return (this.recordId);
    }
@@ -258,7 +258,7 @@ public class AuditSingleInput implements Serializable
    /*******************************************************************************
     ** Setter for recordId
     *******************************************************************************/
-   public void setRecordId(Integer recordId)
+   public void setRecordId(Serializable recordId)
    {
       this.recordId = recordId;
    }
@@ -268,7 +268,7 @@ public class AuditSingleInput implements Serializable
    /*******************************************************************************
     ** Fluent setter for recordId
     *******************************************************************************/
-   public AuditSingleInput withRecordId(Integer recordId)
+   public AuditSingleInput withRecordId(Serializable recordId)
    {
       this.recordId = recordId;
       return (this);
@@ -277,17 +277,18 @@ public class AuditSingleInput implements Serializable
 
 
    /*******************************************************************************
-    **
+    ** Populate this input from a table and record, extracting the primary key
+    ** and security key values.
     *******************************************************************************/
    public AuditSingleInput forRecord(QTableMetaData table, QRecord record)
    {
-      setRecordId(record.getValueInteger(table.getPrimaryKeyField())); // todo support non-integer
+      setRecordId(record.getValue(table.getPrimaryKeyField()));
       setAuditTableName(table.getName());
 
       this.securityKeyValues = new HashMap<>();
       for(RecordSecurityLock recordSecurityLock : RecordSecurityLockFilters.filterForReadLocks(CollectionUtils.nonNullList(table.getRecordSecurityLocks())))
       {
-         this.securityKeyValues.put(recordSecurityLock.getFieldName(), record.getValueInteger(recordSecurityLock.getFieldName()));
+         this.securityKeyValues.put(recordSecurityLock.getFieldName(), record.getValue(recordSecurityLock.getFieldName()));
       }
 
       return (this);

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/audits/AuditsMetaDataProvider.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/audits/AuditsMetaDataProvider.java
@@ -43,7 +43,17 @@ import com.kingsrook.qqq.backend.core.processes.implementations.audits.GetAudits
 
 
 /*******************************************************************************
+ ** MetaData provider for the QQQ audit system tables.
  **
+ ** By default, the audit table's recordId field is INTEGER, which supports
+ ** auditing tables with integer primary keys. To audit tables with String or
+ ** UUID primary keys, configure the provider with a STRING recordId type:
+ **
+ ** <pre>
+ ** new AuditsMetaDataProvider()
+ **    .withRecordIdType(QFieldType.STRING)
+ **    .defineAll(qInstance, backendName, enricher);
+ ** </pre>
  *******************************************************************************/
 public class AuditsMetaDataProvider
 {
@@ -51,6 +61,8 @@ public class AuditsMetaDataProvider
    public static final String TABLE_NAME_AUDIT_USER   = "auditUser";
    public static final String TABLE_NAME_AUDIT        = "audit";
    public static final String TABLE_NAME_AUDIT_DETAIL = "auditDetail";
+
+   private QFieldType recordIdType = QFieldType.INTEGER;
 
 
 
@@ -230,7 +242,7 @@ public class AuditsMetaDataProvider
          .withField(new QFieldMetaData("id", QFieldType.LONG))
          .withField(new QFieldMetaData("auditTableId", QFieldType.INTEGER).withPossibleValueSourceName(TABLE_NAME_AUDIT_TABLE))
          .withField(new QFieldMetaData("auditUserId", QFieldType.INTEGER).withPossibleValueSourceName(TABLE_NAME_AUDIT_USER))
-         .withField(new QFieldMetaData("recordId", QFieldType.INTEGER))
+         .withField(new QFieldMetaData("recordId", recordIdType))
          .withField(new QFieldMetaData("message", QFieldType.STRING).withMaxLength(250).withBehavior(ValueTooLongBehavior.TRUNCATE_ELLIPSIS))
          .withField(new QFieldMetaData("timestamp", QFieldType.DATE_TIME))
          .withoutCapabilities(Capability.TABLE_INSERT, Capability.TABLE_UPDATE, Capability.TABLE_DELETE);
@@ -257,6 +269,37 @@ public class AuditsMetaDataProvider
          .withField(new QFieldMetaData("oldValue", QFieldType.STRING).withMaxLength(250).withBehavior(ValueTooLongBehavior.TRUNCATE_ELLIPSIS))
          .withField(new QFieldMetaData("newValue", QFieldType.STRING).withMaxLength(250).withBehavior(ValueTooLongBehavior.TRUNCATE_ELLIPSIS))
          .withoutCapabilities(Capability.TABLE_INSERT, Capability.TABLE_UPDATE, Capability.TABLE_DELETE);
+   }
+
+
+
+   /*******************************************************************************
+    ** Getter for recordIdType
+    *******************************************************************************/
+   public QFieldType getRecordIdType()
+   {
+      return (this.recordIdType);
+   }
+
+
+
+   /*******************************************************************************
+    ** Setter for recordIdType
+    *******************************************************************************/
+   public void setRecordIdType(QFieldType recordIdType)
+   {
+      this.recordIdType = recordIdType;
+   }
+
+
+
+   /*******************************************************************************
+    ** Fluent setter for recordIdType
+    *******************************************************************************/
+   public AuditsMetaDataProvider withRecordIdType(QFieldType recordIdType)
+   {
+      this.recordIdType = recordIdType;
+      return (this);
    }
 
 }

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/processes/implementations/audits/GetAuditsForRecordProcess.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/processes/implementations/audits/GetAuditsForRecordProcess.java
@@ -85,7 +85,7 @@ public class GetAuditsForRecordProcess implements MetaDataProducerInterface<QPro
             .withCode(new QCodeReference(getClass()))
             .withInputData(new QFunctionInputMetaData()
                .withField(new QFieldMetaData("tableName", QFieldType.STRING).withIsRequired(true))
-               .withField(new QFieldMetaData("recordId", QFieldType.INTEGER).withIsRequired(true))
+               .withField(new QFieldMetaData("recordId", QFieldType.STRING).withIsRequired(true))
                .withField(new QFieldMetaData("isSortAscending", QFieldType.BOOLEAN).withDefaultValue("false"))
                .withField(new QFieldMetaData("limit", QFieldType.INTEGER).withDefaultValue("1000"))
                .withField(new QFieldMetaData("includeChildren", QFieldType.BOOLEAN).withDefaultValue("false"))
@@ -120,7 +120,7 @@ public class GetAuditsForRecordProcess implements MetaDataProducerInterface<QPro
 
       QQueryFilter filter = new QQueryFilter()
          .withCriteria(new QFilterCriteria(AuditsMetaDataProvider.TABLE_NAME_AUDIT_TABLE + ".name", QCriteriaOperator.EQUALS, tableName))
-         .withCriteria(new QFilterCriteria("recordId", QCriteriaOperator.EQUALS, runBackendStepInput.getValueInteger("recordId")))
+         .withCriteria(new QFilterCriteria("recordId", QCriteriaOperator.EQUALS, runBackendStepInput.getValueString("recordId")))
          .withOrderBy(new QFilterOrderBy("timestamp", sortDirection))
          .withOrderBy(new QFilterOrderBy("id", sortDirection))
          .withOrderBy(new QFilterOrderBy("auditDetail.id", true));

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/audits/AuditsMetaDataProviderTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/audits/AuditsMetaDataProviderTest.java
@@ -1,0 +1,143 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2025.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.audits;
+
+
+import com.kingsrook.qqq.backend.core.BaseTest;
+import com.kingsrook.qqq.backend.core.context.QContext;
+import com.kingsrook.qqq.backend.core.exceptions.QException;
+import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
+import com.kingsrook.qqq.backend.core.model.metadata.fields.QFieldMetaData;
+import com.kingsrook.qqq.backend.core.model.metadata.fields.QFieldType;
+import com.kingsrook.qqq.backend.core.model.metadata.tables.QTableMetaData;
+import com.kingsrook.qqq.backend.core.utils.TestUtils;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+
+/*******************************************************************************
+ ** Unit test for AuditsMetaDataProvider
+ *******************************************************************************/
+class AuditsMetaDataProviderTest extends BaseTest
+{
+
+   /*******************************************************************************
+    ** Test that the default recordIdType is INTEGER for backwards compatibility.
+    *******************************************************************************/
+   @Test
+   void testDefaultRecordIdTypeIsInteger() throws QException
+   {
+      QInstance qInstance = QContext.getQInstance();
+      new AuditsMetaDataProvider().defineAll(qInstance, TestUtils.MEMORY_BACKEND_NAME, null);
+
+      QTableMetaData auditTable = qInstance.getTable(AuditsMetaDataProvider.TABLE_NAME_AUDIT);
+      assertNotNull(auditTable);
+
+      QFieldMetaData recordIdField = auditTable.getField("recordId");
+      assertNotNull(recordIdField);
+      assertEquals(QFieldType.INTEGER, recordIdField.getType());
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that recordIdType can be configured as STRING.
+    *******************************************************************************/
+   @Test
+   void testRecordIdTypeConfiguredAsString() throws QException
+   {
+      QInstance qInstance = QContext.getQInstance();
+      new AuditsMetaDataProvider()
+         .withRecordIdType(QFieldType.STRING)
+         .defineAll(qInstance, TestUtils.MEMORY_BACKEND_NAME, null);
+
+      QTableMetaData auditTable = qInstance.getTable(AuditsMetaDataProvider.TABLE_NAME_AUDIT);
+      assertNotNull(auditTable);
+
+      QFieldMetaData recordIdField = auditTable.getField("recordId");
+      assertNotNull(recordIdField);
+      assertEquals(QFieldType.STRING, recordIdField.getType());
+   }
+
+
+
+   /*******************************************************************************
+    ** Test the getter and setter for recordIdType.
+    *******************************************************************************/
+   @Test
+   void testRecordIdTypeGetterSetter()
+   {
+      AuditsMetaDataProvider provider = new AuditsMetaDataProvider();
+
+      //////////////////////////////////
+      // verify default is INTEGER    //
+      //////////////////////////////////
+      assertEquals(QFieldType.INTEGER, provider.getRecordIdType());
+
+      ////////////////////////////////////////
+      // verify setter changes the value    //
+      ////////////////////////////////////////
+      provider.setRecordIdType(QFieldType.STRING);
+      assertEquals(QFieldType.STRING, provider.getRecordIdType());
+
+      //////////////////////////////////////////
+      // verify fluent setter returns self    //
+      //////////////////////////////////////////
+      AuditsMetaDataProvider result = provider.withRecordIdType(QFieldType.LONG);
+      assertEquals(provider, result);
+      assertEquals(QFieldType.LONG, provider.getRecordIdType());
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that all audit tables are created when defineAll is called.
+    *******************************************************************************/
+   @Test
+   void testDefineAllCreatesAllTables() throws QException
+   {
+      QInstance qInstance = QContext.getQInstance();
+      new AuditsMetaDataProvider().defineAll(qInstance, TestUtils.MEMORY_BACKEND_NAME, null);
+
+      //////////////////////////////////////
+      // verify all four tables are added //
+      //////////////////////////////////////
+      assertNotNull(qInstance.getTable(AuditsMetaDataProvider.TABLE_NAME_AUDIT));
+      assertNotNull(qInstance.getTable(AuditsMetaDataProvider.TABLE_NAME_AUDIT_TABLE));
+      assertNotNull(qInstance.getTable(AuditsMetaDataProvider.TABLE_NAME_AUDIT_USER));
+      assertNotNull(qInstance.getTable(AuditsMetaDataProvider.TABLE_NAME_AUDIT_DETAIL));
+
+      /////////////////////////////////////////////
+      // verify possible value sources are added //
+      /////////////////////////////////////////////
+      assertNotNull(qInstance.getPossibleValueSource(AuditsMetaDataProvider.TABLE_NAME_AUDIT_TABLE));
+      assertNotNull(qInstance.getPossibleValueSource(AuditsMetaDataProvider.TABLE_NAME_AUDIT_USER));
+      assertNotNull(qInstance.getPossibleValueSource(AuditsMetaDataProvider.TABLE_NAME_AUDIT));
+
+      /////////////////////////////////////////
+      // verify process is added             //
+      /////////////////////////////////////////
+      assertNotNull(qInstance.getProcess("GetAuditsForRecord"));
+   }
+
+}


### PR DESCRIPTION
## Summary

Adds configurable `recordIdType` to `AuditsMetaDataProvider`, enabling audit trails for tables with UUID or string primary keys.

- `AuditsMetaDataProvider.withRecordIdType(QFieldType)` - configure INTEGER (default) or STRING
- `AuditSingleInput.recordId` changed from `Integer` to `Serializable`
- `DMLAuditAction` performs runtime type checking against audit table configuration
- Full backwards compatibility - default remains INTEGER

## Test Plan

- [x] `AuditsMetaDataProviderTest` - verifies default INTEGER and configurable STRING
- [x] `DMLAuditActionTest` - tests STRING mode with insert/update/delete operations
- [x] `AuditActionTest` - tests Serializable recordId handling
- [x] All 1244 existing tests pass

Closes #322