### PR TITLE
fix(rdbms): quote camelCase PK in UPDATE WHERE clause

### DIFF
--- a/qqq-backend-module-postgres/src/test/java/com/kingsrook/qqq/backend/module/postgres/BaseTest.java
+++ b/qqq-backend-module-postgres/src/test/java/com/kingsrook/qqq/backend/module/postgres/BaseTest.java
@@ -68,7 +68,7 @@ public class BaseTest
    @BeforeAll
    void baseBeforeAll()
    {
-      postgres = new PostgreSQLContainer("postgres:16-alpine")
+      postgres = new PostgreSQLContainer("postgres:17-alpine")
          .withDatabaseName("qqq_test")
          .withUsername("test")
          .withPassword("test")

--- a/qqq-backend-module-postgres/src/test/java/com/kingsrook/qqq/backend/module/postgres/TestUtils.java
+++ b/qqq-backend-module-postgres/src/test/java/com/kingsrook/qqq/backend/module/postgres/TestUtils.java
@@ -86,6 +86,7 @@ public class TestUtils
    public static final String TABLE_NAME_LINE_ITEM_EXTRINSIC = "orderLineExtrinsic";
    public static final String TABLE_NAME_WAREHOUSE           = "warehouse";
    public static final String TABLE_NAME_WAREHOUSE_STORE_INT = "warehouseStoreInt";
+   public static final String TABLE_NAME_CAMEL_CASE_ID_TABLE = "camelCaseIdTable";
 
    public static final String SECURITY_KEY_STORE_ALL_ACCESS = "storeAllAccess";
 
@@ -147,6 +148,7 @@ public class TestUtils
       qInstance.addTable(defineTablePersonalIdCard());
       qInstance.addJoin(defineJoinPersonAndPersonalIdCard());
       addOmsTablesAndJoins(qInstance);
+      qInstance.addTable(defineTableCamelCaseId());
       qInstance.setAuthentication(defineAuthentication());
       return (qInstance);
    }
@@ -258,6 +260,29 @@ public class TestUtils
          .withField(new QFieldMetaData("startTime", QFieldType.TIME).withBackendName("start_time"))
          .withBackendDetails(new PostgreSQLTableBackendDetails()
             .withTableName("person"));
+   }
+
+
+
+   /*******************************************************************************
+    ** Defines a table with a camelCase primary key for testing identifier quoting.
+    **
+    ** This table tests that UPDATE operations properly quote camelCase column
+    ** names in WHERE clauses (issue #327).
+    **
+    ** @return the CamelCaseIdTable metadata
+    *******************************************************************************/
+   public static QTableMetaData defineTableCamelCaseId()
+   {
+      return new QTableMetaData()
+         .withName(TABLE_NAME_CAMEL_CASE_ID_TABLE)
+         .withLabel("Camel Case Id Table")
+         .withBackendName(DEFAULT_BACKEND_NAME)
+         .withPrimaryKeyField("testId")
+         .withField(new QFieldMetaData("testId", QFieldType.STRING).withBackendName("testId"))
+         .withField(new QFieldMetaData("name", QFieldType.STRING))
+         .withBackendDetails(new PostgreSQLTableBackendDetails()
+            .withTableName("camel_case_id_table"));
    }
 
 

--- a/qqq-backend-module-postgres/src/test/resources/prime-test-database.sql
+++ b/qqq-backend-module-postgres/src/test/resources/prime-test-database.sql
@@ -20,6 +20,7 @@
 --
 
 -- Drop all tables and sequences in correct order (reverse dependency)
+DROP TABLE IF EXISTS camel_case_id_table CASCADE;
 DROP SEQUENCE IF EXISTS line_item_extrinsic_id_seq CASCADE;
 DROP SEQUENCE IF EXISTS order_line_id_seq CASCADE;
 DROP SEQUENCE IF EXISTS order_id_seq CASCADE;
@@ -244,3 +245,13 @@ CREATE TABLE line_item_extrinsic
    value VARCHAR(80)
 );
 ALTER SEQUENCE line_item_extrinsic_id_seq RESTART WITH 1;
+
+-- Table with camelCase primary key to test identifier quoting (issue #327)
+CREATE TABLE camel_case_id_table
+(
+   "testId" VARCHAR(36) PRIMARY KEY,
+   name VARCHAR(80)
+);
+
+INSERT INTO camel_case_id_table ("testId", name) VALUES ('uuid-1', 'Test Record 1');
+INSERT INTO camel_case_id_table ("testId", name) VALUES ('uuid-2', 'Test Record 2');

--- a/qqq-backend-module-rdbms/src/main/java/com/kingsrook/qqq/backend/module/rdbms/actions/RDBMSUpdateAction.java
+++ b/qqq-backend-module-rdbms/src/main/java/com/kingsrook/qqq/backend/module/rdbms/actions/RDBMSUpdateAction.java
@@ -206,7 +206,7 @@ public class RDBMSUpdateAction extends AbstractRDBMSAction implements UpdateInte
       String tableName = escapeIdentifier(getTableName(table));
       return ("UPDATE " + tableName
          + " SET " + columns
-         + " WHERE " + getColumnName(table.getField(table.getPrimaryKeyField())) + " ");
+         + " WHERE " + escapeIdentifier(getColumnName(table.getField(table.getPrimaryKeyField()))) + " ");
    }
 
 


### PR DESCRIPTION
## Summary

- Add `escapeIdentifier()` to primary key column in UPDATE WHERE clause
- Add PostgreSQL 17 test with camelCase primary key column

**Root cause:** `RDBMSUpdateAction.writeUpdateSQLPrefix()` was missing `escapeIdentifier()` around the primary key column name, causing PostgreSQL to lowercase unquoted identifiers.

## Test Plan

- [x] New test `testUpdateWithCamelCasePrimaryKey` verifies UPDATE with camelCase PK on PostgreSQL 17
- [x] All existing RDBMS and PostgreSQL tests pass

Closes #327