### PR TITLE
feat(auth): add customizer support to OAuth2AuthenticationModule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,20 @@
 
 ## Project Overview
 
-QQQ is a low-code application framework for engineers by Kingsrook, LLC. It uses metadata-driven architecture where applications are defined through configuration rather than code generation.
+QQQ is a low-code application framework for engineers by QRun-IO, LLC (formerly Kingsrook). It uses metadata-driven architecture where applications are defined through configuration rather than code generation.
 
-**Current Version:** 0.36.0-SNAPSHOT
+**Current Version:** 0.34.0-SNAPSHOT
 **License:** Apache-2.0
-**Java Version:** 21 LTS
+**Java Version:** 17+
+
+## Session Continuity
+
+To continue from a previous session, say **"continue from last session"** and Claude will:
+1. Read `docs/SESSION.md` for current context
+2. Read `docs/TODO.md` for pending tasks
+3. Resume work from last checkpoint
+
+**Important:** Session state is kept in `./docs/` directory, NOT in `~/.claude/`.
 
 ## Repository Structure
 
@@ -218,14 +227,8 @@ new IsolatedSpaRouteProvider()
 - `CONTRIBUTING.md` - Contribution guidelines
 - `checkstyle/config.xml` - Checkstyle rules
 - `qqq-middleware-javalin/ISOLATED_SPA_ROUTE_PROVIDER.md` - SPA documentation
-- `docs/SESSION-STATE.md` - Current session state for continuity
-
-## Session Continuity
-
-To continue from a previous session, read `docs/SESSION-STATE.md` for:
-- Current branch and recent work
-- Open PRs and issues
-- Next steps and context
+- `docs/SESSION.md` - Current session state for continuity
+- `docs/TODO.md` - Active task tracking
 
 ## Recent Learnings
 
@@ -239,3 +242,12 @@ To continue from a previous session, read `docs/SESSION-STATE.md` for:
 - `AuditsMetaDataProvider.withRecordIdType(QFieldType)` configures audit table PK type
 - Default is INTEGER (backwards compatible)
 - STRING mode allows auditing tables with UUID/string PKs
+
+### OAuth2 Authentication Customizer Support
+- `OAuth2AuthenticationModule` now supports `QAuthenticationModuleCustomizerInterface`
+- Customizers are called on both initial login AND session resume
+- JWT payload is passed to `customizeSession()` via `context.get("jwtPayloadJsonObject")`
+- `finalCustomizeSession()` is called after session creation for final adjustments
+- This enables apps to set security keys that persist across requests
+- See issue #334 and PR #337 for details
+- Future: #336 proposes `QSessionStoreInterface` QBit for session persistence

--- a/docs/PLAN-license-migration.md
+++ b/docs/PLAN-license-migration.md
@@ -1,0 +1,77 @@
+# PLAN: Apache 2.0 License Migration
+
+## Goal
+
+Migrate all QRun-IO open-source repositories from AGPL-3.0 to Apache-2.0.
+
+## Approach
+
+1. Update LICENSE files in all repos (DONE)
+2. Update source file headers to simplified format pointing to LICENSE
+3. Update pom.xml license declarations
+4. Update README badges and license text
+
+## New License Header
+
+```java
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2025 QRun-IO, LLC
+ *
+ * See the LICENSE file in the repository root for details.
+ */
+```
+
+## Files Affected
+
+### Phase 1: LICENSE/NOTICE files (COMPLETE)
+- 24/25 repos updated via GitHub MCP
+- qbit-template not found
+
+### Phase 2: Source File Headers (IN PROGRESS)
+- ~5,747 Java files with AGPL headers
+- 9 checkstyle/license.txt template files
+
+### Phase 3: Config Files (PENDING)
+- ~20 pom.xml files with `<licenses>` section
+- ~15 README.md files with AGPL mentions
+- 1 package.json (qqq-frontend-core)
+
+## Steps
+
+### Update checkstyle/license.txt templates
+1. [x] qqq/checkstyle/license.txt - DONE
+2. [ ] Other 8 repos - copy same template
+
+### Update Java source files
+Option A: Write script to bulk-replace old header with new
+Option B: Run `mvn checkstyle:check` to identify violations, fix manually
+Option C: Add spotless plugin to auto-format
+
+Recommended: Script approach for bulk update, then checkstyle to verify
+
+### Update pom.xml files
+Replace:
+```xml
+<licenses>
+  <license>
+    <name>GNU Affero General Public License v3.0</name>
+    <url>https://www.gnu.org/licenses/agpl-3.0-standalone.html</url>
+  </license>
+</licenses>
+```
+
+With:
+```xml
+<licenses>
+  <license>
+    <name>Apache License, Version 2.0</name>
+    <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+  </license>
+</licenses>
+```
+
+## Open Questions
+
+- Should we update copyright year range in all files (2021-2022 -> 2021-2025)?
+- Should qbit repos have their own copyright line or reference QRun-IO?

--- a/docs/SESSION.md
+++ b/docs/SESSION.md
@@ -1,0 +1,53 @@
+# Session State
+
+**Last Updated:** 2026-01-08
+**Branch:** `feature/334-session-security-keys`
+**Last Task:** OAuth2 Authentication Customizer Support (Issue #334)
+
+## Current Context
+
+Implemented customizer support for OAuth2AuthenticationModule so that applications can set security keys via `customizeSession()` that persist across requests (including session resume).
+
+## Completed This Session
+
+1. Added customizer support to `OAuth2AuthenticationModule.java`
+   - Added `getCustomizer()` method with memoization
+   - Added `finalCustomizeSession()` helper method
+   - Call `customizeSession()` in `createSessionFromToken()` with JWT payload
+   - Call `finalCustomizeSession()` after login and session resume
+
+2. Created unit test `OAuth2AuthenticationModuleTest.java`
+
+3. Added WireMock dependency to qqq-backend-core for integration testing
+
+4. Created integration tests `OAuth2AuthenticationModuleIntegrationTest.java`
+   - Tests session resume flow
+   - Tests PKCE token exchange flow
+   - Tests `finalCustomizeSession()` is called
+
+5. Created PR #337 (merged to develop)
+
+6. Created GitHub issue #336 for Phase 2 (QSessionStoreInterface QBit)
+
+## Open PRs/Issues
+
+- **PR #337** - feat(auth): add customizer support to OAuth2AuthenticationModule (OPEN)
+- **Issue #336** - Feature: Pluggable QSessionStoreInterface QBit (OPEN, future work)
+
+## Background Work (Paused)
+
+License migration from AGPL-3.0 to Apache-2.0 - see `docs/PLAN-license-migration.md` and `docs/TODO.md`
+
+## To Continue
+
+Say **"continue from last session"** and Claude will:
+1. Read this file and `docs/TODO.md`
+2. Check PR #337 status
+3. Resume any pending work
+
+## Key Files Modified
+
+- `qqq-backend-core/src/main/java/.../OAuth2AuthenticationModule.java`
+- `qqq-backend-core/src/test/java/.../OAuth2AuthenticationModuleTest.java`
+- `qqq-backend-core/src/test/java/.../OAuth2AuthenticationModuleIntegrationTest.java`
+- `qqq-backend-core/pom.xml` (added WireMock dependency)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,57 @@
+# TODO
+
+## Active Work: Issue #334 - OAuth2 Session Security Keys
+
+### Completed
+- [x] Add customizer fields to OAuth2AuthenticationModule
+- [x] Add `getCustomizer()` method with memoization
+- [x] Add `finalCustomizeSession()` helper method
+- [x] Modify `createSessionFromToken()` to call `customizeSession()`
+- [x] Add `finalCustomizeSession()` calls in `createSession()` flows
+- [x] Add unit tests for customizer support
+- [x] Add WireMock dependency for integration testing
+- [x] Add integration tests with mock OIDC server
+- [x] Create PR #337
+- [x] Create GitHub issue #336 for Phase 2 QBit
+
+### Pending
+- [ ] PR #337 review and merge
+- [ ] (Future) Implement #336 QSessionStoreInterface QBit
+
+---
+
+## Background: License Migration (Paused)
+
+See `docs/PLAN-license-migration.md` for details.
+
+### Completed
+- [x] Push LICENSE, NOTICE, README to all 25 repos
+- [x] Delete old LICENSE.txt files from qqq and qqq-android
+- [x] Update `checkstyle/license.txt` with new simplified header
+
+### Pending
+- [ ] Update Java source file headers (~5,747 files)
+- [ ] Update pom.xml `<licenses>` sections (~20 files)
+- [ ] Update README.md AGPL references (~15 files)
+- [ ] Update package.json license field (qqq-frontend-core)
+- [ ] Run checkstyle to verify headers
+
+---
+
+## Notes
+
+### OAuth2 Customizer Usage
+```java
+// In your customizer implementation
+public void customizeSession(QInstance qInstance, QSession qSession, Map<String, Object> context)
+{
+   JSONObject jwtPayload = (JSONObject) context.get("jwtPayloadJsonObject");
+   // Extract claims and set security keys
+   qSession.withSecurityKeyValue("myKey", jwtPayload.getString("customClaim"));
+}
+```
+
+### Related Issues/PRs
+- Issue #334 - Session Security Keys not persisted (FIXED)
+- PR #337 - OAuth2 customizer support (OPEN)
+- Issue #336 - QSessionStoreInterface QBit (FUTURE)

--- a/qqq-backend-core/pom.xml
+++ b/qqq-backend-core/pom.xml
@@ -308,6 +308,12 @@
          <scope>test</scope>
       </dependency>
       <dependency>
+         <groupId>org.wiremock</groupId>
+         <artifactId>wiremock</artifactId>
+         <version>3.13.0</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>org.testcontainers</groupId>
          <artifactId>testcontainers</artifactId>
          <version>2.0.3</version>

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/modules/authentication/implementations/OAuth2AuthenticationModuleIntegrationTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/modules/authentication/implementations/OAuth2AuthenticationModuleIntegrationTest.java
@@ -1,0 +1,403 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2025.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.modules.authentication.implementations;
+
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.kingsrook.qqq.backend.core.actions.tables.InsertAction;
+import com.kingsrook.qqq.backend.core.context.QContext;
+import com.kingsrook.qqq.backend.core.model.actions.tables.insert.InsertInput;
+import com.kingsrook.qqq.backend.core.model.metadata.QBackendMetaData;
+import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
+import com.kingsrook.qqq.backend.core.model.metadata.authentication.OAuth2AuthenticationMetaData;
+import com.kingsrook.qqq.backend.core.model.metadata.code.QCodeReference;
+import com.kingsrook.qqq.backend.core.model.metadata.fields.QFieldMetaData;
+import com.kingsrook.qqq.backend.core.model.metadata.fields.QFieldType;
+import com.kingsrook.qqq.backend.core.model.metadata.tables.QTableMetaData;
+import com.kingsrook.qqq.backend.core.model.metadata.tables.UniqueKey;
+import com.kingsrook.qqq.backend.core.model.session.QSession;
+import com.kingsrook.qqq.backend.core.model.session.QSystemUserSession;
+import com.kingsrook.qqq.backend.core.modules.authentication.QAuthenticationModuleCustomizerInterface;
+import com.kingsrook.qqq.backend.core.modules.authentication.implementations.model.UserSession;
+import com.kingsrook.qqq.backend.core.modules.backend.implementations.memory.MemoryBackendModule;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/*******************************************************************************
+ ** Integration tests for OAuth2AuthenticationModule with WireMock
+ *******************************************************************************/
+class OAuth2AuthenticationModuleIntegrationTest
+{
+   private static final String BACKEND_NAME = "memory";
+   private static final String REDIRECT_STATE_TABLE = "oauthRedirectState";
+
+   private WireMockServer wireMockServer;
+   private QInstance      qInstance;
+
+
+
+   /***************************************************************************
+    ** Set up WireMock server and QInstance before each test
+    ***************************************************************************/
+   @BeforeEach
+   void setUp() throws Exception
+   {
+      ///////////////////////////////
+      // Start WireMock on a random port
+      ///////////////////////////////
+      wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+      wireMockServer.start();
+      WireMock.configureFor("localhost", wireMockServer.port());
+
+      ///////////////////////////////
+      // Build the QInstance
+      ///////////////////////////////
+      qInstance = buildQInstance(wireMockServer.baseUrl());
+      QContext.init(qInstance, new QSystemUserSession());
+   }
+
+
+
+   /***************************************************************************
+    ** Clean up after each test
+    ***************************************************************************/
+   @AfterEach
+   void tearDown()
+   {
+      if(wireMockServer != null)
+      {
+         wireMockServer.stop();
+      }
+      QContext.clear();
+   }
+
+
+
+   /***************************************************************************
+    ** Test that customizer is called when resuming a session via sessionUUID
+    ***************************************************************************/
+   @Test
+   void testSessionResume_customizerIsCalled() throws Exception
+   {
+      ///////////////////////////////////////////////////////////////////////
+      // Create a valid JWT access token that expires in the future        //
+      ///////////////////////////////////////////////////////////////////////
+      String accessToken = createTestJwt("test-user@example.com", "Test User", Map.of("customClaim", "claimValue"));
+
+      ///////////////////////////////////////////////////////////////////////
+      // Insert a UserSession record that we'll look up by UUID            //
+      ///////////////////////////////////////////////////////////////////////
+      String sessionUuid = "test-session-uuid-12345";
+      insertUserSession(sessionUuid, accessToken, "test-user@example.com");
+
+      ///////////////////////////////////////////////////////////////////////
+      // Create session via sessionUUID (resume flow)                      //
+      ///////////////////////////////////////////////////////////////////////
+      OAuth2AuthenticationModule module = new OAuth2AuthenticationModule();
+      Map<String, String> context = new HashMap<>();
+      context.put("sessionUUID", sessionUuid);
+
+      QSession session = module.createSession(qInstance, context);
+
+      ///////////////////////////////////////////////////////////////////////
+      // Verify session was created correctly                              //
+      ///////////////////////////////////////////////////////////////////////
+      assertNotNull(session);
+      assertNotNull(session.getUser());
+      assertEquals("test-user@example.com", session.getUser().getIdReference());
+      assertEquals("Test User", session.getUser().getFullName());
+
+      ///////////////////////////////////////////////////////////////////////
+      // Verify the customizer was called and set the security key         //
+      ///////////////////////////////////////////////////////////////////////
+      assertTrue(session.hasSecurityKeyValue("testSecurityKey", "fromCustomizer"),
+         "Customizer should have set security key on session resume");
+   }
+
+
+
+   /***************************************************************************
+    ** Test that customizer is called during token exchange (PKCE flow)
+    ***************************************************************************/
+   @Test
+   void testTokenExchange_customizerIsCalled() throws Exception
+   {
+      ///////////////////////////////////////////////////////////////////////
+      // Create a valid JWT that will be returned by the mock token endpoint
+      ///////////////////////////////////////////////////////////////////////
+      String accessToken = createTestJwt("pkce-user@example.com", "PKCE User", Map.of("role", "admin"));
+
+      ///////////////////////////////////////////////////////////////////////
+      // Set up WireMock stubs for OIDC discovery and token endpoint       //
+      ///////////////////////////////////////////////////////////////////////
+      stubOidcDiscovery();
+      stubTokenEndpoint(accessToken);
+
+      ///////////////////////////////////////////////////////////////////////
+      // Create session via code+redirectUri+codeVerifier (PKCE flow)      //
+      ///////////////////////////////////////////////////////////////////////
+      OAuth2AuthenticationModule module = new OAuth2AuthenticationModule();
+      Map<String, String> context = new HashMap<>();
+      context.put("code", "test-authorization-code");
+      context.put("redirectUri", "http://localhost:3000/callback");
+      context.put("codeVerifier", "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk");
+
+      QSession session = module.createSession(qInstance, context);
+
+      ///////////////////////////////////////////////////////////////////////
+      // Verify session was created correctly                              //
+      ///////////////////////////////////////////////////////////////////////
+      assertNotNull(session);
+      assertNotNull(session.getUser());
+      assertEquals("pkce-user@example.com", session.getUser().getIdReference());
+      assertEquals("PKCE User", session.getUser().getFullName());
+
+      ///////////////////////////////////////////////////////////////////////
+      // Verify the customizer was called and set the security key         //
+      ///////////////////////////////////////////////////////////////////////
+      assertTrue(session.hasSecurityKeyValue("testSecurityKey", "fromCustomizer"),
+         "Customizer should have set security key during token exchange");
+   }
+
+
+
+   /***************************************************************************
+    ** Test that finalCustomizeSession is called after session resume
+    ***************************************************************************/
+   @Test
+   void testSessionResume_finalCustomizeSessionIsCalled() throws Exception
+   {
+      String accessToken = createTestJwt("final-test@example.com", "Final Test User", Map.of());
+      String sessionUuid = "final-test-uuid-67890";
+      insertUserSession(sessionUuid, accessToken, "final-test@example.com");
+
+      OAuth2AuthenticationModule module = new OAuth2AuthenticationModule();
+      Map<String, String> context = new HashMap<>();
+      context.put("sessionUUID", sessionUuid);
+
+      QSession session = module.createSession(qInstance, context);
+
+      ///////////////////////////////////////////////////////////////////////
+      // Verify finalCustomizeSession was called (sets a different key)    //
+      ///////////////////////////////////////////////////////////////////////
+      assertTrue(session.hasSecurityKeyValue("finalSecurityKey", "fromFinalCustomizer"),
+         "finalCustomizeSession should have been called on session resume");
+   }
+
+
+
+   /***************************************************************************
+    ** Build a QInstance configured for OAuth2 with memory backend
+    ***************************************************************************/
+   private QInstance buildQInstance(String baseUrl) throws Exception
+   {
+      QInstance instance = new QInstance();
+
+      //////////////////////////////////
+      // Add memory backend           //
+      //////////////////////////////////
+      instance.addBackend(new QBackendMetaData()
+         .withName(BACKEND_NAME)
+         .withBackendType(MemoryBackendModule.class));
+
+      //////////////////////////////////
+      // Add UserSession table        //
+      //////////////////////////////////
+      instance.addTable(new QTableMetaData()
+         .withName(UserSession.TABLE_NAME)
+         .withBackendName(BACKEND_NAME)
+         .withPrimaryKeyField("id")
+         .withUniqueKey(new UniqueKey("uuid"))
+         .withField(new QFieldMetaData("id", QFieldType.INTEGER))
+         .withField(new QFieldMetaData("uuid", QFieldType.STRING))
+         .withField(new QFieldMetaData("accessToken", QFieldType.STRING))
+         .withField(new QFieldMetaData("userId", QFieldType.STRING))
+         .withField(new QFieldMetaData("createDate", QFieldType.DATE_TIME))
+         .withField(new QFieldMetaData("modifyDate", QFieldType.DATE_TIME)));
+
+      //////////////////////////////////
+      // Add redirect state table     //
+      //////////////////////////////////
+      instance.addTable(new QTableMetaData()
+         .withName(REDIRECT_STATE_TABLE)
+         .withBackendName(BACKEND_NAME)
+         .withPrimaryKeyField("id")
+         .withField(new QFieldMetaData("id", QFieldType.INTEGER))
+         .withField(new QFieldMetaData("state", QFieldType.STRING).withMaxLength(100))
+         .withField(new QFieldMetaData("redirectUri", QFieldType.STRING)));
+
+      //////////////////////////////////
+      // Configure OAuth2 authentication
+      //////////////////////////////////
+      OAuth2AuthenticationMetaData authMetaData = new OAuth2AuthenticationMetaData();
+      authMetaData.setName("oauth2");
+      authMetaData.setBaseUrl(baseUrl);
+      authMetaData.setClientId("test-client-id");
+      authMetaData.setClientSecret("test-client-secret");
+      authMetaData.setScopes("openid profile email");
+      authMetaData.setUserSessionTableName(UserSession.TABLE_NAME);
+      authMetaData.setRedirectStateTableName(REDIRECT_STATE_TABLE);
+      authMetaData.setCustomizer(new QCodeReference(TestOAuth2Customizer.class));
+      instance.setAuthentication(authMetaData);
+
+      return instance;
+   }
+
+
+
+   /***************************************************************************
+    ** Create a test JWT token with the given claims
+    ***************************************************************************/
+   private String createTestJwt(String email, String name, Map<String, Object> additionalClaims)
+   {
+      JSONObject header = new JSONObject();
+      header.put("alg", "HS256");
+      header.put("typ", "JWT");
+
+      JSONObject payload = new JSONObject();
+      payload.put("sub", email);
+      payload.put("email", email);
+      payload.put("name", name);
+      payload.put("exp", Instant.now().plus(1, ChronoUnit.HOURS).getEpochSecond());
+      payload.put("iat", Instant.now().getEpochSecond());
+
+      for(Map.Entry<String, Object> entry : additionalClaims.entrySet())
+      {
+         payload.put(entry.getKey(), entry.getValue());
+      }
+
+      String headerBase64 = Base64.getUrlEncoder().withoutPadding().encodeToString(header.toString().getBytes());
+      String payloadBase64 = Base64.getUrlEncoder().withoutPadding().encodeToString(payload.toString().getBytes());
+
+      // For testing purposes, we use a fake signature (the JWT library only decodes, doesn't verify in our usage)
+      return headerBase64 + "." + payloadBase64 + ".fake-signature";
+   }
+
+
+
+   /***************************************************************************
+    ** Insert a UserSession record into the memory backend
+    ***************************************************************************/
+   private void insertUserSession(String uuid, String accessToken, String userId) throws Exception
+   {
+      InsertInput insertInput = new InsertInput();
+      insertInput.setTableName(UserSession.TABLE_NAME);
+      insertInput.setRecords(java.util.List.of(new com.kingsrook.qqq.backend.core.model.data.QRecord()
+         .withValue("uuid", uuid)
+         .withValue("accessToken", accessToken)
+         .withValue("userId", userId)));
+
+      new InsertAction().execute(insertInput);
+   }
+
+
+
+   /***************************************************************************
+    ** Stub the OIDC discovery endpoint
+    ***************************************************************************/
+   private void stubOidcDiscovery()
+   {
+      String discoveryResponse = new JSONObject()
+         .put("issuer", wireMockServer.baseUrl())
+         .put("authorization_endpoint", wireMockServer.baseUrl() + "/authorize")
+         .put("token_endpoint", wireMockServer.baseUrl() + "/oauth/token")
+         .put("userinfo_endpoint", wireMockServer.baseUrl() + "/userinfo")
+         .put("jwks_uri", wireMockServer.baseUrl() + "/.well-known/jwks.json")
+         .put("response_types_supported", new org.json.JSONArray().put("code"))
+         .put("subject_types_supported", new org.json.JSONArray().put("public"))
+         .put("id_token_signing_alg_values_supported", new org.json.JSONArray().put("RS256"))
+         .toString();
+
+      wireMockServer.stubFor(get(urlEqualTo("/.well-known/openid-configuration"))
+         .willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(discoveryResponse)));
+   }
+
+
+
+   /***************************************************************************
+    ** Stub the token endpoint to return the given access token
+    ***************************************************************************/
+   private void stubTokenEndpoint(String accessToken)
+   {
+      String tokenResponse = new JSONObject()
+         .put("access_token", accessToken)
+         .put("token_type", "Bearer")
+         .put("expires_in", 3600)
+         .toString();
+
+      wireMockServer.stubFor(post(urlEqualTo("/oauth/token"))
+         .willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(tokenResponse)));
+   }
+
+
+
+   /*******************************************************************************
+    ** Test customizer that sets security keys when called
+    *******************************************************************************/
+   public static class TestOAuth2Customizer implements QAuthenticationModuleCustomizerInterface
+   {
+      @Override
+      public void customizeSession(QInstance qInstance, QSession qSession, Map<String, Object> context)
+      {
+         /////////////////////////////////////////////////////////////////
+         // Set a security key to prove customizeSession was called     //
+         /////////////////////////////////////////////////////////////////
+         qSession.withSecurityKeyValue("testSecurityKey", "fromCustomizer");
+      }
+
+
+
+      @Override
+      public void finalCustomizeSession(QInstance qInstance, QSession qSession)
+      {
+         /////////////////////////////////////////////////////////////////
+         // Set a different security key to prove finalCustomizeSession //
+         // was called                                                   //
+         /////////////////////////////////////////////////////////////////
+         qSession.withSecurityKeyValue("finalSecurityKey", "fromFinalCustomizer");
+      }
+   }
+
+}

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/modules/authentication/implementations/OAuth2AuthenticationModuleTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/modules/authentication/implementations/OAuth2AuthenticationModuleTest.java
@@ -1,0 +1,132 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2025.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.modules.authentication.implementations;
+
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Map;
+import com.kingsrook.qqq.backend.core.BaseTest;
+import com.kingsrook.qqq.backend.core.context.QContext;
+import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
+import com.kingsrook.qqq.backend.core.model.metadata.authentication.OAuth2AuthenticationMetaData;
+import com.kingsrook.qqq.backend.core.model.metadata.code.QCodeReference;
+import com.kingsrook.qqq.backend.core.model.session.QSession;
+import com.kingsrook.qqq.backend.core.modules.authentication.QAuthenticationModuleCustomizerInterface;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/*******************************************************************************
+ ** Unit test for OAuth2AuthenticationModule
+ *******************************************************************************/
+class OAuth2AuthenticationModuleTest extends BaseTest
+{
+   /***************************************************************************
+    ** Test that the customizer is called when configured
+    ***************************************************************************/
+   @Test
+   void testCustomizerCalledOnCreateSessionFromToken() throws Exception
+   {
+      QInstance qInstance = QContext.getQInstance();
+      OAuth2AuthenticationMetaData authMetaData = new OAuth2AuthenticationMetaData();
+      authMetaData.setName("oauth2");
+      authMetaData.setBaseUrl("https://example.com");
+      authMetaData.setClientId("test-client");
+      authMetaData.setClientSecret("test-secret");
+      authMetaData.setCustomizer(new QCodeReference(TestCustomizer.class));
+      qInstance.setAuthentication(authMetaData);
+
+      //////////////////////////////////////////////////////////////////////////
+      // Create a test JWT token with claims                                  //
+      // JWT format: header.payload.signature (we only need header + payload) //
+      //////////////////////////////////////////////////////////////////////////
+      JSONObject header = new JSONObject();
+      header.put("alg", "none");
+      header.put("typ", "JWT");
+
+      JSONObject payload = new JSONObject();
+      payload.put("sub", "test-user-id");
+      payload.put("email", "test@example.com");
+      payload.put("name", "Test User");
+      payload.put("exp", Instant.now().plus(1, ChronoUnit.HOURS).getEpochSecond());
+      payload.put("iat", Instant.now().getEpochSecond());
+      payload.put("testClaim", "customValue");
+
+      String headerBase64 = Base64.getUrlEncoder().withoutPadding().encodeToString(header.toString().getBytes());
+      String payloadBase64 = Base64.getUrlEncoder().withoutPadding().encodeToString(payload.toString().getBytes());
+      String testJwt = headerBase64 + "." + payloadBase64 + ".fakesignature";
+
+      ///////////////////////////////////////////////////////////////////////
+      // Use reflection to call the private createSessionFromToken method  //
+      ///////////////////////////////////////////////////////////////////////
+      OAuth2AuthenticationModule module = new OAuth2AuthenticationModule();
+      var method = OAuth2AuthenticationModule.class.getDeclaredMethod("createSessionFromToken", String.class);
+      method.setAccessible(true);
+      QSession session = (QSession) method.invoke(module, testJwt);
+
+      ///////////////////////////////////////////////////////////////
+      // Verify the session was created with user info from the JWT //
+      ///////////////////////////////////////////////////////////////
+      assertNotNull(session);
+      assertNotNull(session.getUser());
+      assertEquals("test@example.com", session.getUser().getIdReference());
+      assertEquals("Test User", session.getUser().getFullName());
+
+      ///////////////////////////////////////////////////////////////
+      // Verify the customizer was called and set the security key //
+      ///////////////////////////////////////////////////////////////
+      assertTrue(session.hasSecurityKeyValue("testSecurityKey", "fromCustomizer"));
+   }
+
+
+
+   /*******************************************************************************
+    ** Test customizer that sets a security key when customizeSession is called
+    *******************************************************************************/
+   public static class TestCustomizer implements QAuthenticationModuleCustomizerInterface
+   {
+      @Override
+      public void customizeSession(QInstance qInstance, QSession qSession, Map<String, Object> context)
+      {
+         ///////////////////////////////////////////////////////////
+         // Verify we received the JWT payload in context         //
+         ///////////////////////////////////////////////////////////
+         if(context.containsKey("jwtPayloadJsonObject"))
+         {
+            JSONObject jwtPayload = (JSONObject) context.get("jwtPayloadJsonObject");
+            if(jwtPayload.has("testClaim"))
+            {
+               /////////////////////////////////////////////////////
+               // Set a security key to prove the customizer ran  //
+               /////////////////////////////////////////////////////
+               qSession.withSecurityKeyValue("testSecurityKey", "fromCustomizer");
+            }
+         }
+      }
+   }
+
+}


### PR DESCRIPTION
## Summary

- Add customizer support to OAuth2AuthenticationModule, enabling apps to set security keys via `customizeSession()` on both initial login AND session resume
- Add WireMock integration tests verifying customizer behavior

## Problem

Issue #334: Session security keys set via `QAuthenticationModuleCustomizerInterface.customizeSession()` were not persisted across requests when using OAuth2 authentication. This was because OAuth2AuthenticationModule never called the customizer interface (unlike Auth0AuthenticationModule which does).

## Solution

Mirror Auth0's customizer pattern in OAuth2:
- Call `customizeSession()` with JWT payload when creating session from token
- Call `finalCustomizeSession()` after initial login and session resume
- Pass `jwtPayloadJsonObject` in context so customizers can read JWT claims

## Test plan

- [x] Unit test: customizer called on `createSessionFromToken()`
- [x] Integration test: customizer called on session resume (sessionUUID flow)
- [x] Integration test: customizer called on token exchange (PKCE flow)
- [x] Integration test: `finalCustomizeSession()` called after resume
- [x] All existing tests pass

Fixes #334

Related: #336 (Phase 2 feature request for QSessionStoreInterface QBit)