### PR TITLE
fix(security): upgrade mysql-connector-j and protobuf-java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **WireMock 3.13.2** - Upgraded from 3.13.0 to fix commons-fileupload vulnerability (HIGH)
 - **commons-lang 2.x removed** - Migrated to commons-lang3 3.20.0 (no fix available for 2.x MEDIUM CVE)
 - **iq80 snappy excluded** - Excluded vulnerable snappy from checkstyle plugin dependencies (MEDIUM)
+- **mysql-connector-j 8.4.0** - Migrated from deprecated mysql:mysql-connector-java 8.0.30 (HIGH)
+- **protobuf-java 3.25.5** - Override to fix DoS vulnerability (HIGH)
 
 ### Notes
-- commons-lang3 alert (3.18.0 fix) dismissed - already at 3.20.0
+- commons-lang3 alert dismissed - already at 3.20.0
+- commons-beanutils alerts dismissed - already at fix version 1.11.0
+- jetty-http alerts dismissed - requires Jetty 12.x (Javalin 7.x)
 
 ## [0.35.0] - 2025-12-28
 

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,12 @@
         <artifactId>http2-common</artifactId>
         <version>${jetty.version}</version>
       </dependency>
+      <!-- Security: Override protobuf-java to fix DoS vulnerability (transitive via mysql-connector-j) -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>3.25.5</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>

--- a/qqq-backend-module-rdbms/pom.xml
+++ b/qqq-backend-module-rdbms/pom.xml
@@ -47,10 +47,11 @@
       </dependency>
 
       <!-- 3rd party deps specifically for this module -->
+      <!-- Security: Migrated from deprecated mysql:mysql-connector-java to com.mysql:mysql-connector-j -->
       <dependency>
-         <groupId>mysql</groupId>
-         <artifactId>mysql-connector-java</artifactId>
-         <version>8.0.30</version>
+         <groupId>com.mysql</groupId>
+         <artifactId>mysql-connector-j</artifactId>
+         <version>8.4.0</version>
       </dependency>
       <dependency>
          <groupId>com.mchange</groupId>


### PR DESCRIPTION
## Summary
- Migrate from deprecated `mysql:mysql-connector-java` 8.0.30 to `com.mysql:mysql-connector-j` 8.4.0 (HIGH)
- Override `protobuf-java` to 3.25.5 to fix DoS vulnerability (HIGH)

## Test plan
- [x] Full build verification passed (`mvn clean verify`)
- [x] All existing tests pass
- [ ] CI pipeline passes

## Related
Resolves Dependabot alerts for mysql-connector-java and protobuf-java HIGH severity vulnerabilities.