### PR TITLE
fix(security): add snappy exclusion to checkstyle dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,10 +201,17 @@
         <artifactId>protobuf-java</artifactId>
         <version>3.25.5</version>
       </dependency>
+      <!-- Security: Exclude vulnerable org.iq80.snappy from transitive dependencies -->
       <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.6.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.iq80.snappy</groupId>
+            <artifactId>snappy</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
## Summary
Adds snappy exclusion to the maven-checkstyle-plugin dependency in dependencyManagement.

PR #343 added the exclusion to the plugin configuration, but the plugin is also declared as a dependency that child modules inherit. This completes the exclusion.

## Test plan
- [x] Build compiles successfully
- [ ] CI pipeline passes

Resolves remaining 15 snappy alerts.