### PR TITLE
fix(security): address CodeQL security warnings

### DIFF
--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/instances/SecretsManagerUtils.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/instances/SecretsManagerUtils.java
@@ -172,7 +172,8 @@ public class SecretsManagerUtils
                }
                else
                {
-                  LOG.warn("SecretsManager secret at [" + secretId + "] was a JSON object, but it did not contain a key of [" + name + "] - so returning empty.");
+                  // Security: Don't log secretId as it reveals secret structure
+                  LOG.warn("SecretsManager secret was a JSON object, but it did not contain the expected key - returning empty.");
                   return (Optional.empty());
                }
             }

--- a/qqq-middleware-api/src/main/resources/rapidoc/rapidoc-container.html
+++ b/qqq-middleware-api/src/main/resources/rapidoc/rapidoc-container.html
@@ -89,14 +89,23 @@
       });
    });
 
+   function safeNavigate(url)
+   {
+      // Security: Only allow relative URLs starting with /
+      if (url && url.startsWith('/'))
+      {
+         document.location.href = url;
+      }
+   }
+
    function changeApi()
    {
-      document.location.href = document.getElementById("otherApisSelect").value;
+      safeNavigate(document.getElementById("otherApisSelect").value);
    }
 
    function changeVersion()
    {
-      document.location.href = document.getElementById("otherVersionsSelect").value;
+      safeNavigate(document.getElementById("otherVersionsSelect").value);
    }
 </script>
 </body>

--- a/qqq-openapi/src/main/resources/rapidoc/rapidoc-container.html
+++ b/qqq-openapi/src/main/resources/rapidoc/rapidoc-container.html
@@ -87,14 +87,23 @@
       });
    });
 
+   function safeNavigate(url)
+   {
+      // Security: Only allow relative URLs starting with /
+      if (url && url.startsWith('/'))
+      {
+         document.location.href = url;
+      }
+   }
+
    function changeApi()
    {
-      document.location.href = document.getElementById("otherApisSelect").value;
+      safeNavigate(document.getElementById("otherApisSelect").value);
    }
 
    function changeVersion()
    {
-      document.location.href = document.getElementById("otherVersionsSelect").value;
+      safeNavigate(document.getElementById("otherVersionsSelect").value);
    }
 </script>
 </body>


### PR DESCRIPTION
## Summary
Addresses CodeQL code scanning security warnings.

## Changes

### Rapidoc XSS Prevention (4 alerts)
- Added `safeNavigate()` function that validates URLs start with `/` before navigation
- Prevents XSS attacks via `javascript:` or other malicious URL schemes
- Files: `qqq-openapi` and `qqq-middleware-api` rapidoc-container.html

### Password Hashing Upgrade (1 alert)
- Upgraded from PBKDF2WithHmacSHA1 to PBKDF2WithHmacSHA256
- Increased iterations from 1,000 to 100,000 (OWASP recommended)
- New password format: `sha256:iterations:salt:hash`
- **Backward compatible**: Legacy passwords (`iterations:salt:hash`) still validate using SHA1

### Log Information Disclosure (1 alert)
- Removed `secretId` from log messages in SecretsManagerUtils
- Prevents disclosure of secret management structure

## Test plan
- [x] Build compiles
- [x] TableBasedAuthenticationModuleTest passes (13 tests)
- [ ] CI pipeline passes

## Notes
- Stale workflow alerts (ci.yml, security-audit.yml, pr-security-check.yml) - files no longer exist in repo