### PR TITLE
fix(postgres): quote column name in RETURNING clause

### DIFF
--- a/qqq-backend-module-postgres/src/main/java/com/kingsrook/qqq/backend/module/postgres/strategy/PostgreSQLRDBMSActionStrategy.java
+++ b/qqq-backend-module-postgres/src/main/java/com/kingsrook/qqq/backend/module/postgres/strategy/PostgreSQLRDBMSActionStrategy.java
@@ -64,7 +64,8 @@ public class PostgreSQLRDBMSActionStrategy extends BaseRDBMSActionStrategy
       Connection connection, String sql, List<Object> params,
       QFieldMetaData primaryKeyField) throws SQLException
    {
-      sql = sql + " RETURNING " + getColumnName(primaryKeyField);
+      String quoteString = getIdentifierQuoteString();
+      sql = sql + " RETURNING " + quoteString + getColumnName(primaryKeyField) + quoteString;
 
       try(PreparedStatement statement = connection.prepareStatement(sql))
       {


### PR DESCRIPTION
## Summary
- Fixes #367 - PostgreSQL RETURNING clause now properly quotes camelCase primary key column names
- Without quoting, PostgreSQL folds identifiers to lowercase, causing "column does not exist" errors

## Test plan
- [x] Verified fix in test-portal with `testPatientId` and `testIotDeviceId` columns
- [ ] Run existing postgres module tests