### PR TITLE
feat(tables): improve/formalize support for tables being added to mor…

### DIFF
--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/metadata/MetaDataOutput.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/metadata/MetaDataOutput.java
@@ -22,6 +22,7 @@
 package com.kingsrook.qqq.backend.core.model.actions.metadata;
 
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import com.kingsrook.qqq.backend.core.model.actions.AbstractActionOutput;
@@ -54,6 +55,7 @@ public class MetaDataOutput extends AbstractActionOutput
    private QBrandingMetaData               branding;
    private Map<String, List<QHelpContent>> helpContents;
 
+   private Map<String, String> redirects;
 
 
    /*******************************************************************************
@@ -273,4 +275,68 @@ public class MetaDataOutput extends AbstractActionOutput
    {
       return helpContents;
    }
+
+
+
+   /*******************************************************************************
+    * Getter for redirects
+    * @see #withRedirects(Map)
+    *******************************************************************************/
+   public Map<String, String> getRedirects()
+   {
+      return (this.redirects);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for redirects
+    * @see #withRedirects(Map)
+    *******************************************************************************/
+   public void setRedirects(Map<String, String> redirects)
+   {
+      this.redirects = redirects;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for redirects
+    *
+    * @param redirects
+    * Map of string to string, where the key is the URL path to redirect from, and
+    * the value is the URL path to redirect to.
+    *
+    * <p>The core {@link com.kingsrook.qqq.backend.core.actions.metadata.MetaDataAction}
+    * will build some of these redirects automatically, e.g., for the use case of a
+    * table in multiple apps, but where a user doesn't have permission to all of those apps.</p>
+    *
+    * <p>An app may build its own redirects via a
+    * {@link com.kingsrook.qqq.backend.core.actions.metadata.MetaDataActionCustomizerInterface},
+    * for whatever custom logic is needed.</p>
+    *
+    * @return this
+    *******************************************************************************/
+   public MetaDataOutput withRedirects(Map<String, String> redirects)
+   {
+      this.redirects = redirects;
+      return (this);
+   }
+
+
+
+   /***************************************************************************
+    * Fluent setter to add a single redirect.
+    * @see #withRedirects(Map)
+    ***************************************************************************/
+   public MetaDataOutput withRedirect(String from, String to)
+   {
+      if(this.redirects == null)
+      {
+         this.redirects = new LinkedHashMap<>();
+      }
+      this.redirects.put(from, to);
+      return (this);
+   }
+
 }

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/QInstance.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/QInstance.java
@@ -24,11 +24,13 @@ package com.kingsrook.qqq.backend.core.model.metadata;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -153,6 +155,8 @@ public class QInstance
    private Map<String, String> memoizedTablePaths   = new HashMap<>();
    private Map<String, String> memoizedProcessPaths = new HashMap<>();
 
+   private ListingHash<String, PathWithAffinity> memoizedPathsMap = null;
+
    private JoinGraph joinGraph;
 
 
@@ -250,13 +254,109 @@ public class QInstance
       {
          QContext.withTemporaryContext(new CapturedContext(QContext.getQInstance(), new QSystemUserSession()), () ->
          {
-            MetaDataInput  input  = new MetaDataInput();
-            MetaDataOutput output = new MetaDataAction().execute(input);
-            memoizedTablePaths.put(tableName, searchAppTree(output.getAppTree(), tableName, AppTreeNodeType.TABLE, ""));
+            ////////////////////////////////////////////////////////
+            // get the (memoized) map of name to paths+affinities //
+            ////////////////////////////////////////////////////////
+            ListingHash<String, PathWithAffinity> memoizedPathsMap = getMemoizedPathsMap();
+
+            //////////////////////////////////////////
+            // get the list of paths for this table //
+            //////////////////////////////////////////
+            List<PathWithAffinity> pathWithAffinityList = memoizedPathsMap.get(tableName);
+            if(CollectionUtils.nullSafeHasContents(pathWithAffinityList))
+            {
+               ///////////////////////////////////////////////////////////////////////////
+               // sort the list of paths by affinity (desc), and return the first entry //
+               ///////////////////////////////////////////////////////////////////////////
+               pathWithAffinityList.sort(Comparator.comparing(PathWithAffinity::affinity).reversed());
+               memoizedTablePaths.put(tableName, pathWithAffinityList.getFirst().path);
+            }
+            else
+            {
+               //////////////////////////////////////////////
+               // else, if there are no paths, return null //
+               //////////////////////////////////////////////
+               memoizedTablePaths.put(tableName, null);
+            }
          });
       }
 
       return (memoizedTablePaths.get(tableName));
+   }
+
+
+
+   /***************************************************************************
+    * Get the memoizedPathsMap, building it if necessary.
+    * @see #buildPathsMap()
+    ***************************************************************************/
+   private ListingHash<String, PathWithAffinity> getMemoizedPathsMap() throws QException
+   {
+      if(memoizedPathsMap == null)
+      {
+         memoizedPathsMap = buildPathsMap();
+      }
+
+      return memoizedPathsMap;
+   }
+
+
+
+   /***************************************************************************
+    * build a map (ListingHash) keyed by object (e.g., table, process) names,
+    * with values being lists (typically singletons, but for tables in multiple
+    * apps, multi-valued) of records, containing the path to the table within
+    * an app, and an appAffinity value - indicating which app is preferred to
+    * be used for the table (e.g., in global contexts).
+    *
+    ***************************************************************************/
+   private ListingHash<String, PathWithAffinity> buildPathsMap() throws QException
+   {
+      MetaDataInput                         input    = new MetaDataInput();
+      MetaDataOutput                        output   = new MetaDataAction().execute(input);
+      ListingHash<String, PathWithAffinity> pathsMap = new ListingHash<>();
+      populatePathsMap(pathsMap, output.getAppTree(), "");
+      return (pathsMap);
+   }
+
+
+
+   /***************************************************************************
+    * recursive implementation used by buildPathsMap() to traverse the appTree
+    * and populate the pathsMap.
+    *
+    * @param pathsMap the map to populate (output parameter)
+    * @param appTreeNodes the nodes to process (for top-level call should be
+    *                     the app tree root nodes (from MetaDataAction).
+    * @param path the current path being built (e.g., accumulates entries with
+    *             recursive calls)
+    * @see #buildPathsMap()
+    ***************************************************************************/
+   private void populatePathsMap(ListingHash<String, PathWithAffinity> pathsMap, List<AppTreeNode> appTreeNodes, String path)
+   {
+      for(AppTreeNode appTreeNode : appTreeNodes)
+      {
+         if(appTreeNode.getType().equals(AppTreeNodeType.APP) && CollectionUtils.nullSafeHasContents(appTreeNode.getChildren()))
+         {
+            populatePathsMap(pathsMap, appTreeNode.getChildren(), path + "/" + appTreeNode.getName());
+         }
+         else
+         {
+            Integer affinity = Objects.requireNonNullElse(appTreeNode.getAppAffinity(), Integer.MIN_VALUE);
+            pathsMap.add(appTreeNode.getName(), new PathWithAffinity(path + "/" + appTreeNode.getName(), affinity));
+         }
+      }
+   }
+
+
+
+   /***************************************************************************
+    * private record to associate a path (through apps to a table, process, etc)
+    * with an affinity value indicating which app is preferred to be used for
+    * the table (e.g., in global contexts).
+    ***************************************************************************/
+   private record PathWithAffinity(String path, Integer affinity)
+   {
    }
 
 

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/frontend/AppTreeNode.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/frontend/AppTreeNode.java
@@ -39,12 +39,14 @@ import com.kingsrook.qqq.backend.core.model.metadata.tables.QTableMetaData;
  ** These objects are organized into a tree - where each Node can have 0 or more
  ** other Nodes as children.
  *******************************************************************************/
-public class AppTreeNode
+public class AppTreeNode implements Cloneable
 {
    private AppTreeNodeType   type;
    private String            name;
    private String            label;
    private List<AppTreeNode> children;
+
+   private Integer appAffinity;
 
    private QIcon icon;
 
@@ -166,4 +168,67 @@ public class AppTreeNode
       }
       children.add(childTreeNode);
    }
+
+
+
+   /*******************************************************************************
+    * Getter for appAffinity
+    * @see #withAppAffinity(Integer)
+    *******************************************************************************/
+   public Integer getAppAffinity()
+   {
+      return (this.appAffinity);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for appAffinity
+    * @see #withAppAffinity(Integer)
+    *******************************************************************************/
+   public void setAppAffinity(Integer appAffinity)
+   {
+      this.appAffinity = appAffinity;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for appAffinity
+    *
+    * @param appAffinity
+    * appAffinity level for this child node, as it is related to its parent app.
+    * See {@link QAppMetaData#setChildAppAffinity(String, Integer)}.
+    * @return this
+    *******************************************************************************/
+   public AppTreeNode withAppAffinity(Integer appAffinity)
+   {
+      this.appAffinity = appAffinity;
+      return (this);
+   }
+
+
+
+   /***************************************************************************
+    *
+    ***************************************************************************/
+   @Override
+   public AppTreeNode clone()
+   {
+      try
+      {
+         AppTreeNode clone = (AppTreeNode) super.clone();
+         if(children != null)
+         {
+            clone.children = new ArrayList<>();
+            children.forEach(child -> clone.children.add(child.clone()));
+         }
+         return clone;
+      }
+      catch(CloneNotSupportedException e)
+      {
+         throw new AssertionError();
+      }
+   }
+
 }

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/layout/QAppMetaData.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/layout/QAppMetaData.java
@@ -44,10 +44,12 @@ import com.kingsrook.qqq.backend.core.utils.CollectionUtils;
  *******************************************************************************/
 public class QAppMetaData implements QAppChildMetaData, MetaDataWithPermissionRules, TopLevelMetaDataInterface
 {
+   public static final Integer DEFAULT_SORT_ORDER = 500;
+
    private String name;
    private String label;
 
-   private Integer sortOrder = 500;
+   private Integer sortOrder = DEFAULT_SORT_ORDER;
 
    private QPermissionRules permissionRules;
 
@@ -58,6 +60,8 @@ public class QAppMetaData implements QAppChildMetaData, MetaDataWithPermissionRu
 
    private List<String>      widgets;
    private List<QAppSection> sections;
+
+   private Map<String, Integer> childAppAffinities;
 
    private Map<String, QSupplementalAppMetaData> supplementalMetaData;
 
@@ -519,6 +523,46 @@ public class QAppMetaData implements QAppChildMetaData, MetaDataWithPermissionRu
    {
       this.supplementalMetaData = supplementalMetaData;
       return (this);
+   }
+
+
+
+   /***************************************************************************
+    * set an appAffinity for a child.  Higher values are higher affinity, with
+    * null (the default) considered the lowest. Tiebreaking behavior is not
+    * specified and may differ by use-case (e.g., by front-end), though app
+    * sort-order is recommended.
+    *
+    * <p>The purpose of this appAffinity is not about ordering the children of this
+    * app - but rather - for cases where the same object (e.g. a table) is
+    * referenced by multiple apps, and we want to control which app should be
+    * displayed first when the object is referenced.</p>
+    *
+    * @param childName name of child (e.g., a table name) to set appAffinity for
+    * @param appAffinity appAffinity level, or null to clear any existing appAffinity.
+    *                 Higher values are higher affinity.  null is lowest.
+    ***************************************************************************/
+   public void setChildAppAffinity(String childName, Integer appAffinity)
+   {
+      if(this.childAppAffinities == null)
+      {
+         this.childAppAffinities = new HashMap<>();
+      }
+
+      this.childAppAffinities.put(childName, appAffinity);
+   }
+
+
+
+   /***************************************************************************
+    * get the appAffinity assigned to this child (by name) for this app - null if not set.
+    *
+    * @param childName name of child (e.g., a table name) to get appAffinity for
+    * @return appAffinity level, or null if not set.
+    ***************************************************************************/
+   public Integer getChildAppAffinity(String childName)
+   {
+      return (this.childAppAffinities == null ? null : this.childAppAffinities.get(childName));
    }
 
 }

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/actions/metadata/MetaDataActionTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/actions/metadata/MetaDataActionTest.java
@@ -27,8 +27,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import com.kingsrook.qqq.backend.core.BaseTest;
+import com.kingsrook.qqq.backend.core.actions.permissions.PermissionsHelper;
 import com.kingsrook.qqq.backend.core.context.QContext;
 import com.kingsrook.qqq.backend.core.exceptions.QException;
 import com.kingsrook.qqq.backend.core.model.actions.metadata.MetaDataInput;
@@ -51,6 +53,7 @@ import com.kingsrook.qqq.backend.core.model.metadata.processes.QProcessMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.reporting.QReportMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.tables.QTableMetaData;
 import com.kingsrook.qqq.backend.core.model.session.QSession;
+import com.kingsrook.qqq.backend.core.utils.CollectionUtils;
 import com.kingsrook.qqq.backend.core.utils.TestUtils;
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -450,6 +453,426 @@ class MetaDataActionTest extends BaseTest
       reInitInstanceInContext(instance);
       result = new MetaDataAction().execute(new MetaDataInput());
       assertFalse(result.getTables().isEmpty(), "should be some tables");
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testRedirectsForTableInTwoApps() throws QException
+   {
+      /////////////////////////////////////////////////////////////
+      // update the test instance:                               //
+      // - to have hasAccess permissions                         //
+      // - to have the person table in a second app ("otherApp") //
+      /////////////////////////////////////////////////////////////
+      QInstance qInstance = TestUtils.defineInstance();
+      qInstance.setDefaultPermissionRules(new QPermissionRules().withLevel(PermissionLevel.HAS_ACCESS_PERMISSION));
+
+      qInstance.addApp(new QAppMetaData()
+         .withName("otherApp")
+         .withChild(qInstance.getTable(TestUtils.TABLE_NAME_PERSON)));
+
+      reInitInstanceInContext(qInstance);
+
+      Predicate<AppTreeNode> treeNodeHasPersonTable = at ->
+         at.getChildren().stream().anyMatch(c -> c.getName().equals(TestUtils.TABLE_NAME_PERSON));
+
+      {
+         ////////////////////////////////////////////////////////////
+         // run w/ permission to the table and only the people app //
+         ////////////////////////////////////////////////////////////
+         QContext.setQSession(new QSession().withPermissions(
+            "person.hasAccess",
+            "peopleApp.hasAccess"
+         ));
+         MetaDataOutput metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+
+         ///////////////////////////////////////////////////////////
+         // there should be a redirect from otherApp to peopleApp //
+         ///////////////////////////////////////////////////////////
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/otherApp/person", "/peopleApp/person");
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/otherApp/person/*", "/peopleApp/person");
+         assertThat(metaDataOutput.getAppTree())
+            .filteredOn(treeNodeHasPersonTable)
+            .anyMatch(at -> at.getName().equals(TestUtils.APP_NAME_PEOPLE))
+            .hasSize(1);
+      }
+
+      {
+         ///////////////////////////////////////////////////////////////////////
+         // vice-versa: run w/ permission to the table and only the other app //
+         ///////////////////////////////////////////////////////////////////////
+         QContext.setQSession(new QSession().withPermissions(
+            "person.hasAccess",
+            "otherApp.hasAccess"
+         ));
+         MetaDataOutput metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+
+         ///////////////////////////////////////////////////////////////////
+         // there should be the opposite redirect (peopleApp to otherApp) //
+         ///////////////////////////////////////////////////////////////////
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/peopleApp/person", "/otherApp/person");
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/peopleApp/person/*", "/otherApp/person");
+         assertThat(metaDataOutput.getAppTree())
+            .filteredOn(treeNodeHasPersonTable)
+            .anyMatch(at -> at.getName().equals("otherApp"))
+            .hasSize(1);
+      }
+
+      {
+         ////////////////////////////////////////////////////////////
+         // run with no permissions - there should be no redirects //
+         // and no tables nor apps                                 //
+         ////////////////////////////////////////////////////////////
+         QContext.setQSession(new QSession());
+         MetaDataOutput metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+         assertThat(metaDataOutput.getRedirects()).isNullOrEmpty();
+         assertThat(metaDataOutput.getTables()).isEmpty();
+         assertThat(metaDataOutput.getApps()).isEmpty();
+         assertThat(metaDataOutput.getAppTree()).isEmpty();
+         assertThat(metaDataOutput.getAppTree())
+            .filteredOn(treeNodeHasPersonTable)
+            .hasSize(0);
+      }
+
+      {
+         ///////////////////////////////////////////////////////////////////
+         // run with all permissions - there should still be no redirects //
+         // but this time apps and the table                              //
+         ///////////////////////////////////////////////////////////////////
+         QContext.setQSession(new QSession().withPermissions(PermissionsHelper.getAllAvailablePermissionNames(qInstance)));
+         MetaDataOutput metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+
+         assertThat(metaDataOutput.getRedirects()).isNullOrEmpty();
+
+         assertThat(metaDataOutput.getTables())
+            .isNotEmpty()
+            .containsKey(TestUtils.TABLE_NAME_PERSON);
+
+         assertThat(metaDataOutput.getApps())
+            .isNotEmpty()
+            .containsKey(TestUtils.APP_NAME_PEOPLE)
+            .containsKey("otherApp");
+
+         assertThat(metaDataOutput.getAppTree()).isNotEmpty()
+            .anyMatch(at -> at.getName().equals(TestUtils.APP_NAME_PEOPLE))
+            .anyMatch(at -> at.getName().equals("otherApp"));
+
+         assertThat(metaDataOutput.getAppTree())
+            .filteredOn(treeNodeHasPersonTable)
+            .hasSize(2);
+      }
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testRedirectsForTableInTwoAppsWithNestedApps() throws QException
+   {
+      ///////////////////////////////////////////////////////////////////////////
+      // update the test instance:                                             //
+      // - to have hasAccess permissions                                       //
+      // - to have the person table in a second app ("otherApp/otherChildApp") //
+      ///////////////////////////////////////////////////////////////////////////
+      QInstance qInstance = TestUtils.defineInstance();
+      qInstance.setDefaultPermissionRules(new QPermissionRules().withLevel(PermissionLevel.HAS_ACCESS_PERMISSION));
+
+      qInstance.addApp(new QAppMetaData()
+         .withName("otherChildApp")
+         .withChild(qInstance.getTable(TestUtils.TABLE_NAME_PERSON)));
+
+      qInstance.addApp(new QAppMetaData()
+         .withName("otherApp")
+         .withChild(qInstance.getApp("otherChildApp")));
+
+      reInitInstanceInContext(qInstance);
+
+      Predicate<AppTreeNode> treeNodeHasPersonTable = at -> at.getChildren().stream().anyMatch(c -> c.getName().equals(TestUtils.TABLE_NAME_PERSON))
+         || at.getChildren().stream().anyMatch(c -> CollectionUtils.nonNullList(c.getChildren()).stream().anyMatch(gc -> gc.getName().equals(TestUtils.TABLE_NAME_PERSON)));
+
+      {
+         ////////////////////////////////////////////////////////////
+         // run w/ permission to the table and only the people app //
+         ////////////////////////////////////////////////////////////
+         QContext.setQSession(new QSession().withPermissions(
+            "person.hasAccess",
+            "peopleApp.hasAccess"
+         ));
+         MetaDataOutput metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+
+         /////////////////////////////////////////////////////////////////////////
+         // there should be a redirect from otherApp/otherChildApp to peopleApp //
+         /////////////////////////////////////////////////////////////////////////
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/otherApp/otherChildApp/person", "/peopleApp/person");
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/otherApp/otherChildApp/person/*", "/peopleApp/person");
+         assertThat(metaDataOutput.getAppTree())
+            .filteredOn(treeNodeHasPersonTable)
+            .anyMatch(at -> at.getName().equals(TestUtils.APP_NAME_PEOPLE))
+            .hasSize(1);
+      }
+
+      {
+         ///////////////////////////////////////////////////////////////////////
+         // vice-versa: run w/ permission to the table and only the other app //
+         ///////////////////////////////////////////////////////////////////////
+         QContext.setQSession(new QSession().withPermissions(
+            "person.hasAccess",
+            "otherApp.hasAccess",
+            "otherChildApp.hasAccess"
+         ));
+         MetaDataOutput metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+
+         ///////////////////////////////////////////////////////////////////
+         // there should be the opposite redirect (peopleApp to otherApp) //
+         ///////////////////////////////////////////////////////////////////
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/peopleApp/person", "/otherApp/otherChildApp/person");
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/peopleApp/person/*", "/otherApp/otherChildApp/person");
+         assertThat(metaDataOutput.getAppTree())
+            .filteredOn(treeNodeHasPersonTable)
+            .anyMatch(at -> at.getName().equals("otherApp"))
+            .hasSize(1);
+      }
+
+      {
+         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+         // run with only partial permissions to the otherApp - there should be no redirects, and no way to get to the table. //
+         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+         QContext.setQSession(new QSession().withPermissions(
+            "person.hasAccess",
+            "otherApp.hasAccess"
+         ));
+         MetaDataOutput metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+         assertThat(metaDataOutput.getRedirects()).isNullOrEmpty();
+
+         //////////////////////////////////////////////////////
+         // and again, but with only the child app this time //
+         //////////////////////////////////////////////////////
+         QContext.setQSession(new QSession().withPermissions(
+            "person.hasAccess",
+            "otherChildApp.hasAccess"
+         ));
+         metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+         assertThat(metaDataOutput.getRedirects()).isNullOrEmpty();
+      }
+
+      {
+         ///////////////////////////////////////////////////////////////////
+         // run with all permissions - there should still be no redirects //
+         // but this time apps and the table                              //
+         ///////////////////////////////////////////////////////////////////
+         QContext.setQSession(new QSession().withPermissions(PermissionsHelper.getAllAvailablePermissionNames(qInstance)));
+         MetaDataOutput metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+
+         assertThat(metaDataOutput.getRedirects()).isNullOrEmpty();
+
+         assertThat(metaDataOutput.getTables())
+            .isNotEmpty()
+            .containsKey(TestUtils.TABLE_NAME_PERSON);
+
+         assertThat(metaDataOutput.getApps())
+            .isNotEmpty()
+            .containsKey(TestUtils.APP_NAME_PEOPLE)
+            .containsKey("otherApp");
+
+         assertThat(metaDataOutput.getAppTree()).isNotEmpty()
+            .anyMatch(at -> at.getName().equals(TestUtils.APP_NAME_PEOPLE))
+            .anyMatch(at -> at.getName().equals("otherApp"));
+
+         assertThat(metaDataOutput.getAppTree())
+            .filteredOn(treeNodeHasPersonTable)
+            .hasSize(2);
+      }
+   }
+
+
+
+   /*******************************************************************************
+    * this test does some verification of appAffinity for choosing which app
+    * to redirect to.
+    *******************************************************************************/
+   @Test
+   void testRedirectsForTableInThreeApps() throws QException
+   {
+      ////////////////////////////////////////////////////////////////
+      // update the test instance:                                  //
+      // - to have hasAccess permissions                            //
+      // - to have the person table in a second app ("otherApp")    //
+      // - AND to have the person table in a third app ("extraApp") //
+      ////////////////////////////////////////////////////////////////
+      QInstance qInstance = TestUtils.defineInstance();
+      qInstance.setDefaultPermissionRules(new QPermissionRules().withLevel(PermissionLevel.HAS_ACCESS_PERMISSION));
+
+      QAppMetaData otherApp = new QAppMetaData()
+         .withName("otherApp")
+         .withChild(qInstance.getTable(TestUtils.TABLE_NAME_PERSON));
+      qInstance.addApp(otherApp);
+      otherApp.setChildAppAffinity(TestUtils.TABLE_NAME_PERSON, 2);
+
+      QAppMetaData extraApp = new QAppMetaData()
+         .withName("extraApp")
+         .withChild(qInstance.getTable(TestUtils.TABLE_NAME_PERSON));
+      qInstance.addApp(extraApp);
+      extraApp.setChildAppAffinity(TestUtils.TABLE_NAME_PERSON, 1);
+
+      reInitInstanceInContext(qInstance);
+
+      Predicate<AppTreeNode> treeNodeHasPersonTable = at ->
+         at.getChildren().stream().anyMatch(c -> c.getName().equals(TestUtils.TABLE_NAME_PERSON));
+
+      {
+         ////////////////////////////////////////////////////////////
+         // run w/ permission to the table and only the people app //
+         ////////////////////////////////////////////////////////////
+         QContext.setQSession(new QSession().withPermissions(
+            "person.hasAccess",
+            "peopleApp.hasAccess"
+         ));
+         MetaDataOutput metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+
+         ////////////////////////////////////////////////////////////////////////
+         // there should be a redirect from otherApp and extraApp to peopleApp //
+         ////////////////////////////////////////////////////////////////////////
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/otherApp/person", "/peopleApp/person");
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/otherApp/person/*", "/peopleApp/person");
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/extraApp/person", "/peopleApp/person");
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/extraApp/person/*", "/peopleApp/person");
+         assertThat(metaDataOutput.getAppTree())
+            .filteredOn(treeNodeHasPersonTable)
+            .anyMatch(at -> at.getName().equals(TestUtils.APP_NAME_PEOPLE))
+            .hasSize(1);
+      }
+
+      {
+         ///////////////////////////////////////////////////////////////////
+         // run with permission to other & extra apps, but not people app //
+         ///////////////////////////////////////////////////////////////////
+         QContext.setQSession(new QSession().withPermissions(
+            "person.hasAccess",
+            "otherApp.hasAccess",
+            "extraApp.hasAccess"
+         ));
+         MetaDataOutput metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+
+         ////////////////////////////////////////////////////////////////////////////////
+         // there should be a redirect from peopleApp to one of them based on affinity //
+         ////////////////////////////////////////////////////////////////////////////////
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/peopleApp/person", "/otherApp/person");
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/peopleApp/person/*", "/otherApp/person");
+         assertThat(metaDataOutput.getAppTree())
+            .filteredOn(treeNodeHasPersonTable)
+            .anyMatch(at -> at.getName().equals("extraApp"))
+            .anyMatch(at -> at.getName().equals("otherApp"))
+            .hasSize(2);
+      }
+
+      {
+         ////////////////////////////////////////////////////////////////////////////////////////////
+         // reverse the affinity values and re-run to confirm the other app is the redirect target //
+         ////////////////////////////////////////////////////////////////////////////////////////////
+         otherApp.setChildAppAffinity(TestUtils.TABLE_NAME_PERSON, 1);
+         extraApp.setChildAppAffinity(TestUtils.TABLE_NAME_PERSON, 2);
+         MetaDataOutput metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/peopleApp/person", "/extraApp/person");
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/peopleApp/person/*", "/extraApp/person");
+      }
+
+      {
+         ////////////////////////////////////////////////////////////////////////
+         // remove affinity values - and the sort should be based on sortOrder //
+         ////////////////////////////////////////////////////////////////////////
+         otherApp.setChildAppAffinity(TestUtils.TABLE_NAME_PERSON, null);
+         extraApp.setChildAppAffinity(TestUtils.TABLE_NAME_PERSON, null);
+         otherApp.setSortOrder(2);
+         extraApp.setSortOrder(1);
+         MetaDataOutput metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/peopleApp/person", "/extraApp/person");
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/peopleApp/person/*", "/extraApp/person");
+      }
+
+      {
+         ///////////////////////////////////////////////////////////////////////////////////
+         // reverse sort-order and re-run to confirm the other app is the redirect target //
+         ///////////////////////////////////////////////////////////////////////////////////
+         otherApp.setSortOrder(1);
+         extraApp.setSortOrder(2);
+         MetaDataOutput metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/peopleApp/person", "/otherApp/person");
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/peopleApp/person/*", "/otherApp/person");
+      }
+
+      {
+         ////////////////////////////////////////////////////
+         // and without sort order, then you get app names //
+         ////////////////////////////////////////////////////
+         otherApp.setSortOrder(null);
+         extraApp.setSortOrder(null);
+         MetaDataOutput metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/peopleApp/person", "/extraApp/person");
+         assertThat(metaDataOutput.getRedirects()).containsEntry("/peopleApp/person/*", "/extraApp/person");
+      }
+
+      {
+         ////////////////////////////////////////////////////////////
+         // run with no permissions - there should be no redirects //
+         // and no tables nor apps                                 //
+         ////////////////////////////////////////////////////////////
+         QContext.setQSession(new QSession());
+         MetaDataOutput metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+         assertThat(metaDataOutput.getRedirects()).isNullOrEmpty();
+         assertThat(metaDataOutput.getTables()).isEmpty();
+         assertThat(metaDataOutput.getApps()).isEmpty();
+         assertThat(metaDataOutput.getAppTree()).isEmpty();
+         assertThat(metaDataOutput.getAppTree())
+            .filteredOn(treeNodeHasPersonTable)
+            .hasSize(0);
+      }
+
+      {
+         ///////////////////////////////////////////////////////////////////
+         // run with all permissions - there should still be no redirects //
+         // but this time apps and the table                              //
+         ///////////////////////////////////////////////////////////////////
+         QContext.setQSession(new QSession().withPermissions(PermissionsHelper.getAllAvailablePermissionNames(qInstance)));
+         MetaDataOutput metaDataOutput = new MetaDataAction().execute(new MetaDataInput());
+
+         assertThat(metaDataOutput.getRedirects()).isNullOrEmpty();
+
+         assertThat(metaDataOutput.getTables())
+            .isNotEmpty()
+            .containsKey(TestUtils.TABLE_NAME_PERSON);
+
+         assertThat(metaDataOutput.getApps())
+            .isNotEmpty()
+            .containsKey(TestUtils.APP_NAME_PEOPLE)
+            .containsKey("extraApp")
+            .containsKey("otherApp");
+
+         assertThat(metaDataOutput.getAppTree()).isNotEmpty()
+            .anyMatch(at -> at.getName().equals(TestUtils.APP_NAME_PEOPLE))
+            .anyMatch(at -> at.getName().equals("extraApp"))
+            .anyMatch(at -> at.getName().equals("otherApp"));
+
+         assertThat(metaDataOutput.getAppTree())
+            .filteredOn(treeNodeHasPersonTable)
+            .hasSize(3);
+      }
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testTableAppAffinity()
+   {
+
    }
 
 


### PR DESCRIPTION
## Description

Improves and formalizes support for tables belonging to multiple applications within QQQ's metadata structure.

## Changes

**Multi-App Table Support:**
- Added `redirects` map to `MetaDataOutput` to redirect users from inaccessible app paths to accessible alternatives for the same table
- Introduced app-affinity concept in `QAppMetaData` allowing developers to specify affinity values when placing tables in apps
- Modified `QInstance.getTablePath` to return the path with the highest affinity value when a table exists in multiple apps

**MetaDataAction Refactoring:**
- Consolidated `PermissionsHelper.getPermissionCheckResult` and `customizer.allowXyz` calls into new `isObjectDenied()` method
- Simplified call sites across the codebase
- Fixed cases where permission checks were incomplete

## Testing

All existing tests pass. The changes maintain backward compatibility while adding new functionality for multi-app table management.