### PR TITLE
feat(menus): Add new QMenu meta data objects, which can be attached t…

### DIFF
--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/instances/QInstanceValidator.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/instances/QInstanceValidator.java
@@ -83,6 +83,7 @@ import com.kingsrook.qqq.backend.core.model.metadata.joins.QJoinMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.layout.QAppChildMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.layout.QAppMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.layout.QAppSection;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.QMenu;
 import com.kingsrook.qqq.backend.core.model.metadata.possiblevalues.QPossibleValueSource;
 import com.kingsrook.qqq.backend.core.model.metadata.possiblevalues.QPossibleValueSourceType;
 import com.kingsrook.qqq.backend.core.model.metadata.processes.QBackendStepMetaData;
@@ -1042,6 +1043,11 @@ public class QInstanceValidator
             if(table.getShareableTableMetaData() != null)
             {
                table.getShareableTableMetaData().validate(qInstance, table, this);
+            }
+
+            for(QMenu menu : CollectionUtils.nonNullList(table.getMenus()))
+            {
+               menu.validate(this, qInstance, table);
             }
 
             runPlugins(QTableMetaData.class, table, qInstance);

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/frontend/QFrontendTableMetaData.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/frontend/QFrontendTableMetaData.java
@@ -47,6 +47,7 @@ import com.kingsrook.qqq.backend.core.model.metadata.fields.QFieldMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.fields.QVirtualFieldMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.help.QHelpContent;
 import com.kingsrook.qqq.backend.core.model.metadata.layout.QIcon;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.QMenu;
 import com.kingsrook.qqq.backend.core.model.metadata.sharing.ShareableTableMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.tables.Capability;
 import com.kingsrook.qqq.backend.core.model.metadata.tables.ExposedJoin;
@@ -90,6 +91,7 @@ public class QFrontendTableMetaData
 
    private ShareableTableMetaData          shareableTableMetaData;
    private Map<String, List<QHelpContent>> helpContents;
+   private List<QMenu>                     menus;
 
    //////////////////////////////////////////////////////////////////////////////////
    // do not add setters.  take values from the source-object in the constructor!! //
@@ -143,6 +145,8 @@ public class QFrontendTableMetaData
          this.sections = tableMetaData.getSections();
 
          this.shareableTableMetaData = tableMetaData.getShareableTableMetaData();
+
+         this.menus = tableMetaData.getMenus();
       }
 
       if(includeJoins)
@@ -487,4 +491,14 @@ public class QFrontendTableMetaData
       return virtualFields;
    }
 
+
+
+   /*******************************************************************************
+    ** Getter for menus
+    **
+    *******************************************************************************/
+   public List<QMenu> getMenus()
+   {
+      return menus;
+   }
 }

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/QMenu.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/QMenu.java
@@ -1,0 +1,269 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import com.kingsrook.qqq.backend.core.instances.QInstanceValidator;
+import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
+import com.kingsrook.qqq.backend.core.model.metadata.QMetaDataObject;
+import com.kingsrook.qqq.backend.core.model.metadata.layout.QIcon;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemInterface;
+import com.kingsrook.qqq.backend.core.utils.CollectionUtils;
+
+
+/*******************************************************************************
+ ** A list of items that can be selected by a user of a qqq application.
+ *******************************************************************************/
+public class QMenu implements QMetaDataObject, Cloneable, QMenuItemContainerInterface
+{
+   private String label;
+   private QIcon  icon;
+
+   private QMenuSlotInterface slot;
+
+   private List<QMenuItemInterface> items;
+
+
+
+   /*******************************************************************************
+    * Getter for label
+    * @see #withLabel(String)
+    *******************************************************************************/
+   public String getLabel()
+   {
+      return (this.label);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for label
+    * @see #withLabel(String)
+    *******************************************************************************/
+   public void setLabel(String label)
+   {
+      this.label = label;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for label
+    *
+    * @param label
+    * user-facing text to display as the label for this menu.  e.g., "File, Edit, View"
+    * or "Actions",
+    * @return this
+    *******************************************************************************/
+   public QMenu withLabel(String label)
+   {
+      this.label = label;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for icon
+    * @see #withIcon(QIcon)
+    *******************************************************************************/
+   public QIcon getIcon()
+   {
+      return (this.icon);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for icon
+    * @see #withIcon(QIcon)
+    *******************************************************************************/
+   public void setIcon(QIcon icon)
+   {
+      this.icon = icon;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for icon
+    *
+    * @param icon
+    * Optional icon to display with this menu.
+    * @return this
+    *******************************************************************************/
+   public QMenu withIcon(QIcon icon)
+   {
+      this.icon = icon;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for slot
+    * @see #withSlot(QMenuSlotInterface)
+    *******************************************************************************/
+   public QMenuSlotInterface getSlot()
+   {
+      return (this.slot);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for slot
+    * @see #withSlot(QMenuSlotInterface)
+    *******************************************************************************/
+   public void setSlot(QMenuSlotInterface slot)
+   {
+      this.slot = slot;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for slot
+    *
+    * @param slot
+    * Where this menu is displayed.  e.g., on a query screen as the actions menu,
+    * or on a view screen as an additional custom menu.
+    * @return this
+    *******************************************************************************/
+   public QMenu withSlot(QMenuSlotInterface slot)
+   {
+      this.slot = slot;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for items
+    * @see #withItems(List)
+    *******************************************************************************/
+   public List<QMenuItemInterface> getItems()
+   {
+      return (this.items);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for items
+    * @see #withItems(List)
+    *******************************************************************************/
+   public void setItems(List<QMenuItemInterface> items)
+   {
+      this.items = items;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for items
+    *
+    * @param items
+    * Contents of the menu.
+    * @return this
+    *******************************************************************************/
+   public QMenu withItems(List<QMenuItemInterface> items)
+   {
+      this.items = items;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Fluently add a single item
+    *
+    * @param item
+    * one item to add to the menu.
+    * @return this
+    *******************************************************************************/
+   public QMenu withItem(QMenuItemInterface item)
+   {
+      if(this.items == null)
+      {
+         this.items = new ArrayList<>();
+      }
+      this.items.add(item);
+      return (this);
+   }
+
+
+
+   /***************************************************************************
+    * As part of QInstanceValidation, verify that the meta-data in this object
+    * is all fully valid.
+    *
+    * <p>Subclasses should generally include a call to super.validate</p>
+    ***************************************************************************/
+   public void validate(QInstanceValidator validator, QInstance qInstance, QMetaDataObject parentObject)
+   {
+      validator.assertCondition(slot != null, "Missing a slot for menu item [" + getLabel() + "] in " + parentObject);
+      for(QMenuItemInterface menuItem : CollectionUtils.nonNullList(items))
+      {
+         menuItem.validate(validator, qInstance, parentObject);
+      }
+   }
+
+
+
+   /***************************************************************************
+    * Creates and returns a deep copy of this menu.
+    *
+    * <p>The cloned menu will have its own copy of the items list, with each
+    * item also being cloned. This ensures that modifications to the cloned
+    * menu or its items will not affect the original.</p>
+    *
+    * @return a deep clone of this menu
+    * @throws RuntimeException if cloning is not supported (should not occur)
+    ***************************************************************************/
+   @Override
+   public QMenu clone()
+   {
+      try
+      {
+         QMenu clone = (QMenu) super.clone();
+
+         if(items != null)
+         {
+            List<QMenuItemInterface> cloneItems = new ArrayList<>();
+            for(QMenuItemInterface item : items)
+            {
+               cloneItems.add(item.clone());
+            }
+            clone.setItems(cloneItems);
+         }
+
+         return clone;
+      }
+      catch(CloneNotSupportedException e)
+      {
+         throw new RuntimeException(e);
+      }
+   }
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/QMenuItemContainerInterface.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/QMenuItemContainerInterface.java
@@ -1,0 +1,48 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus;
+
+
+import java.util.List;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemInterface;
+
+
+/*******************************************************************************
+ ** Interface for objects that contain a collection of menu items.
+ **
+ ** <p>This interface is implemented by both menus and menu items that can
+ ** contain other items (such as sub-menus and sub-lists). It provides a
+ ** common way to access the items within a container.</p>
+ **
+ ** @see QMenu
+ ** @see com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemSubMenu
+ ** @see com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemSubList
+ *******************************************************************************/
+public interface QMenuItemContainerInterface
+{
+   /***************************************************************************
+    * Returns the list of menu items contained within this container.
+    *
+    * @return the list of menu items, which may be empty but should not be null
+    ***************************************************************************/
+   List<QMenuItemInterface> getItems();
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/QMenuSlot.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/QMenuSlot.java
@@ -1,0 +1,55 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus;
+
+
+/*******************************************************************************
+ ** Enumeration of standard menu slot locations where menus can be displayed
+ ** in a QQQ application.
+ **
+ ** <p>Menus are positioned in specific "slots" within the application UI.
+ ** Each slot represents a different location and context where a menu can
+ ** appear. This enum provides the core-known slot values that are recognized
+ ** by the QQQ framework.</p>
+ **
+ ** <p>Slots are categorized by screen type (VIEW_SCREEN vs QUERY_SCREEN) and
+ ** purpose (ACTIONS vs ADDITIONAL). The ACTIONS slots typically contain
+ ** primary actions for the screen, while ADDITIONAL slots are for
+ ** supplementary menus.</p>
+ **
+ ** @see QMenuSlotInterface
+ ** @see QMenu#withSlot(QMenuSlotInterface)
+ *******************************************************************************/
+public enum QMenuSlot implements QMenuSlotInterface
+{
+   /** Menu slot for primary actions on a record view screen */
+   VIEW_SCREEN_ACTIONS,
+
+   /** Menu slot for additional/custom menus on a record view screen. */
+   VIEW_SCREEN_ADDITIONAL,
+
+   /** Menu slot for primary actions on a query screen (list/search screen). */
+   QUERY_SCREEN_ACTIONS,
+
+   /** Menu slot for additional/custom menus on a query screen. */
+   QUERY_SCREEN_ADDITIONAL
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/QMenuSlotInterface.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/QMenuSlotInterface.java
@@ -1,0 +1,39 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus;
+
+
+import com.kingsrook.qqq.backend.core.model.metadata.QMetaDataObject;
+
+
+/*******************************************************************************
+ * Interface to mark objets that can be used as a "slot", e.g., where a menu
+ * should be used or displayed in an application.
+ *
+ * <p>See core-known values in {@link QMenuSlot}.</p>
+ *
+ * <p>Frontend modules can define their own slots by implementing this interface
+ * (e.g., typically in an enum like QMenuSlot)</p>
+ *******************************************************************************/
+public interface QMenuSlotInterface extends QMetaDataObject
+{
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/adjusters/QMenuAdjuster.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/adjusters/QMenuAdjuster.java
@@ -1,0 +1,273 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus.adjusters;
+
+
+import java.util.Iterator;
+import java.util.ListIterator;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.QMenuItemContainerInterface;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemInterface;
+import com.kingsrook.qqq.backend.core.utils.CollectionUtils;
+
+
+/*******************************************************************************
+ ** Utility class for programmatically modifying menu structures.
+ **
+ ** <p>This class provides static methods to adjust menus and menu items
+ ** after they have been created. Common operations include:</p>
+ ** <ul>
+ **   <li>Removing items (first match or all matches)</li>
+ **   <li>Adding items (before, after, first, or last position)</li>
+ **   <li>Replacing items</li>
+ ** </ul>
+ **
+ ** <p>All operations use {@link QMenuItemMatcher} to locate target items
+ ** within the menu structure. Operations recursively search through nested
+ ** sub-menus and sub-lists.</p>
+ **
+ ** @see QMenuItemMatcher
+ *******************************************************************************/
+public class QMenuAdjuster
+{
+
+   /***************************************************************************
+    * Removes the first menu item that matches the given matcher.
+    *
+    * <p>Searches recursively through the menu structure and removes only
+    * the first matching item found. Stops searching after the first removal.</p>
+    *
+    * @param menuItemContainer the menu item container to search
+    * @param matcher the matcher used to identify the item to remove
+    * @return true if an item was removed, false otherwise
+    ***************************************************************************/
+   public static boolean removeFirst(QMenuItemContainerInterface menuItemContainer, QMenuItemMatcher matcher)
+   {
+      int removeCount = remove(menuItemContainer, matcher, false);
+      return (removeCount == 1);
+   }
+
+
+
+   /***************************************************************************
+    * Removes all menu items that match the given matcher.
+    *
+    * <p>Searches recursively through the entire menu structure and removes
+    * all items that match the matcher's criteria.</p>
+    *
+    * @param menuItemContainer the menu item container to search
+    * @param matcher the matcher used to identify items to remove
+    * @return the number of items that were removed
+    ***************************************************************************/
+   public static int removeAll(QMenuItemContainerInterface menuItemContainer, QMenuItemMatcher matcher)
+   {
+      return (remove(menuItemContainer, matcher, true));
+   }
+
+
+
+   /***************************************************************************
+    * Internal method that performs the actual removal operation.
+    *
+    * @param menuItemContainer the menu item container to search
+    * @param matcher the matcher used to identify items
+    * @param removeAll if true, remove all matches; if false, remove only the first
+    * @return the number of items removed
+    ***************************************************************************/
+   private static int remove(QMenuItemContainerInterface menuItemContainer, QMenuItemMatcher matcher, boolean removeAll)
+   {
+      int                          noRemoved = 0;
+      Iterator<QMenuItemInterface> iterator  = CollectionUtils.nonNullList(menuItemContainer.getItems()).iterator();
+      while(iterator.hasNext())
+      {
+         QMenuItemInterface item = iterator.next();
+
+         if(matcher.doesItemMatch(item))
+         {
+            iterator.remove();
+            noRemoved++;
+
+            if(!removeAll)
+            {
+               break;
+            }
+         }
+
+         if(item instanceof QMenuItemContainerInterface subContainer)
+         {
+            noRemoved += remove(subContainer, matcher, removeAll);
+
+            if(!removeAll && noRemoved > 0)
+            {
+               break;
+            }
+         }
+      }
+      return noRemoved;
+   }
+
+
+
+   /***************************************************************************
+    * Adds a new menu item immediately after the first item that matches the matcher.
+    *
+    * <p>Searches recursively through the menu structure. If a matching item
+    * is found, the new item is inserted immediately after it. If no match is
+    * found, no changes are made.</p>
+    *
+    * @param menuItemContainer the menu item container to modify
+    * @param newItem the menu item to add
+    * @param matcher the matcher used to locate the insertion point
+    * @return true if the item was successfully added, false if no match was found
+    ***************************************************************************/
+   public static boolean addAfter(QMenuItemContainerInterface menuItemContainer, QMenuItemInterface newItem, QMenuItemMatcher matcher)
+   {
+      return addBeforeOrAfter(menuItemContainer, newItem, matcher, false);
+   }
+
+
+
+   /***************************************************************************
+    * Adds a new menu item immediately before the first item that matches the matcher.
+    *
+    * <p>Searches recursively through the menu structure. If a matching item
+    * is found, the new item is inserted immediately before it. If no match is
+    * found, no changes are made.</p>
+    *
+    * @param menuItemContainer the menu item container to modify
+    * @param newItem the menu item to add
+    * @param matcher the matcher used to locate the insertion point
+    * @return true if the item was successfully added, false if no match was found
+    ***************************************************************************/
+   public static boolean addBefore(QMenuItemContainerInterface menuItemContainer, QMenuItemInterface newItem, QMenuItemMatcher matcher)
+   {
+      return addBeforeOrAfter(menuItemContainer, newItem, matcher, true);
+   }
+
+
+
+   /***************************************************************************
+    * Internal method that performs the before/after insertion operation.
+    *
+    * @param menuItemContainer the container to modify
+    * @param newItem the item to add
+    * @param matcher the matcher used to locate the insertion point
+    * @param isBefore if true, insert before the match; if false, insert after
+    * @return true if the item was successfully added, false otherwise
+    ***************************************************************************/
+   private static boolean addBeforeOrAfter(QMenuItemContainerInterface menuItemContainer, QMenuItemInterface newItem, QMenuItemMatcher matcher, boolean isBefore)
+   {
+      ListIterator<QMenuItemInterface> iterator = CollectionUtils.nonNullList(menuItemContainer.getItems()).listIterator();
+      while(iterator.hasNext())
+      {
+         QMenuItemInterface item = iterator.next();
+
+         if(matcher.doesItemMatch(item))
+         {
+            if(isBefore)
+            {
+               iterator.previous();
+            }
+            iterator.add(newItem);
+            return (true);
+         }
+
+         if(item instanceof QMenuItemContainerInterface subContainer)
+         {
+            boolean found = addBeforeOrAfter(subContainer, newItem, matcher, isBefore);
+            if(found)
+            {
+               return (true);
+            }
+         }
+      }
+
+      return (false);
+   }
+
+
+
+   /***************************************************************************
+    * Adds a new menu item at the end of a menu item container.
+    *
+    * @param menuItemContainer the menu item container to modify
+    * @param newItem the menu item to add
+    ***************************************************************************/
+   public static void addLast(QMenuItemContainerInterface menuItemContainer, QMenuItemInterface newItem)
+   {
+      menuItemContainer.getItems().addLast(newItem);
+   }
+
+
+
+   /***************************************************************************
+    * Adds a new menu item at the start of a menu item container.
+    *
+    * @param menuItemContainer the menu item container to modify
+    * @param newItem the menu item to add
+    ***************************************************************************/
+   public static void addFirst(QMenuItemContainerInterface menuItemContainer, QMenuItemInterface newItem)
+   {
+      menuItemContainer.getItems().addFirst(newItem);
+   }
+
+
+
+   /***************************************************************************
+    * Replace the first menu that matches the given matcher with a replacement
+    * item.
+    *
+    * <p>Searches recursively through the menu structure. If a matching item
+    * is found, the new item replace it. If no match is found, no changes are
+    * made.</p>
+    *
+    * @param menuItemContainer the menu item container to modify
+    * @param replacementItem the menu item to add to the container
+    * @param matcher the matcher used to locate the item to be replaced by the
+    *                replacementItem
+    * @return true if the item was successfully added, false if no match was found
+    ***************************************************************************/
+   public static boolean replaceItem(QMenuItemContainerInterface menuItemContainer, QMenuItemInterface replacementItem, QMenuItemMatcher matcher)
+   {
+      ListIterator<QMenuItemInterface> iterator = CollectionUtils.nonNullList(menuItemContainer.getItems()).listIterator();
+      while(iterator.hasNext())
+      {
+         QMenuItemInterface item = iterator.next();
+
+         if(matcher.doesItemMatch(item))
+         {
+            iterator.set(replacementItem);
+            return (true);
+         }
+
+         if(item instanceof QMenuItemContainerInterface subContainer)
+         {
+            boolean found = replaceItem(subContainer, replacementItem, matcher);
+            if(found)
+            {
+               return (true);
+            }
+         }
+      }
+
+      return (false);
+   }
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/adjusters/QMenuItemMatcher.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/adjusters/QMenuItemMatcher.java
@@ -1,0 +1,157 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus.adjusters;
+
+
+import java.util.Objects;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.QCriteriaOperator;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.QFilterCriteria;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemBuiltIn;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemInterface;
+import com.kingsrook.qqq.backend.core.modules.backend.implementations.utils.BackendQueryFilterUtils;
+
+
+/*******************************************************************************
+ ** Utility class for matching menu items based on various criteria.
+ **
+ ** <p>This class provides a flexible way to identify menu items within a menu
+ ** structure. It supports matching by:</p>
+ ** <ul>
+ **   <li>Exact item instance equality</li>
+ **   <li>Built-in option type (for QMenuItemBuiltIn items)</li>
+ **   <li>Item class type</li>
+ **   <li>Label text using filter criteria operators</li>
+ ** </ul>
+ **
+ ** <p>Used primarily by {@link QMenuAdjuster} to locate items for modification
+ ** or removal operations.</p>
+ **
+ ** @see QMenuAdjuster
+ *******************************************************************************/
+public class QMenuItemMatcher
+{
+   private QMenuItemInterface                      item;
+   private QMenuItemBuiltIn.BuiltInOptionInterface builtInOption;
+   private Class<? extends QMenuItemInterface>     menuItemClass;
+   private QFilterCriteria                         labelCriteria;
+
+
+
+   /*******************************************************************************
+    ** Constructor that matches items by exact instance equality.
+    **
+    ** @param item the specific menu item instance to match
+    *******************************************************************************/
+   public QMenuItemMatcher(QMenuItemInterface item)
+   {
+      this.item = item;
+   }
+
+
+
+   /*******************************************************************************
+    ** Constructor that matches built-in menu items by their option type.
+    **
+    ** @param builtInOption the built-in option to match (e.g., NEW, EDIT, DELETE)
+    *******************************************************************************/
+   public QMenuItemMatcher(QMenuItemBuiltIn.BuiltInOptionInterface builtInOption)
+   {
+      this.builtInOption = builtInOption;
+   }
+
+
+
+   /*******************************************************************************
+    ** Constructor that matches items by their class type.
+    **
+    ** @param menuItemClass the class type to match (e.g., QMenuItemDivider.class)
+    *******************************************************************************/
+   public QMenuItemMatcher(Class<? extends QMenuItemInterface> menuItemClass)
+   {
+      this.menuItemClass = menuItemClass;
+   }
+
+
+
+   /*******************************************************************************
+    ** Constructor that matches items by label (doing an EQUALS match)
+    **
+    ** @param labelValue the label value to match against
+    *******************************************************************************/
+   public QMenuItemMatcher(String labelValue)
+   {
+      this(QCriteriaOperator.EQUALS, labelValue);
+   }
+
+
+
+   /*******************************************************************************
+    ** Constructor that matches items by label text using a filter criteria operator.
+    **
+    ** @param operator the comparison operator (e.g., EQUALS, CONTAINS)
+    ** @param labelValue the label value to match against
+    *******************************************************************************/
+   public QMenuItemMatcher(QCriteriaOperator operator, String labelValue)
+   {
+      this.labelCriteria = new QFilterCriteria("label", operator, labelValue);
+   }
+
+
+
+   /***************************************************************************
+    * Determines whether the given menu item matches this matcher's criteria.
+    *
+    * <p>The method checks the item against all configured matching criteria
+    * (instance, built-in option, class type, or label). Returns true if any
+    * of the configured criteria match.</p>
+    *
+    * @param item the menu item to test
+    * @return true if the item matches this matcher's criteria, false otherwise
+    ***************************************************************************/
+   public boolean doesItemMatch(QMenuItemInterface item)
+   {
+      if(this.item != null)
+      {
+         if(Objects.equals(this.item, item))
+         {
+            return (true);
+         }
+      }
+      else if(builtInOption != null)
+      {
+         if(item instanceof QMenuItemBuiltIn builtIn && Objects.equals(builtIn.getOption(), builtInOption))
+         {
+            return (true);
+         }
+      }
+      else if(menuItemClass != null && menuItemClass.isInstance(item))
+      {
+         return (true);
+      }
+      else if(labelCriteria != null && BackendQueryFilterUtils.doesCriteriaMatch(labelCriteria, "label", item.getLabel()))
+      {
+         return (true);
+      }
+
+      return (false);
+   }
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/defaults/QMenuDefaultViewScreenActionsMenu.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/defaults/QMenuDefaultViewScreenActionsMenu.java
@@ -1,0 +1,190 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus.defaults;
+
+
+import com.kingsrook.qqq.backend.core.model.metadata.layout.QIcon;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.QMenu;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.QMenuSlot;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.adjusters.QMenuAdjuster;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemBuiltIn;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemDivider;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemSubList;
+import static com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemBuiltIn.DefaultOptions.ALL_TABLES_PROCESS_LIST;
+import static com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemBuiltIn.DefaultOptions.AUDIT;
+import static com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemBuiltIn.DefaultOptions.COPY;
+import static com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemBuiltIn.DefaultOptions.DELETE;
+import static com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemBuiltIn.DefaultOptions.DEVELOPER_MODE;
+import static com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemBuiltIn.DefaultOptions.EDIT;
+import static com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemBuiltIn.DefaultOptions.NEW;
+import static com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemBuiltIn.DefaultOptions.THIS_TABLE_PROCESS_LIST;
+
+
+/*******************************************************************************
+ ** Default menu definition for the view screen actions slot.
+ **
+ ** <p>This class provides a standard menu configuration for record view screens
+ ** that includes common actions like New, Copy, Edit, * Delete, and process
+ * lists. The menu is structured with header items, dividers, and footer items
+ * for better organization.</p>
+ **
+ ** <p>This default menu can be customized or replaced by applications as needed
+ ** using menu adjusters or by providing custom menu definitions.</p>
+ **
+ ** @see QMenuSlot#VIEW_SCREEN_ACTIONS
+ ** @see QMenuAdjuster
+ *******************************************************************************/
+public class QMenuDefaultViewScreenActionsMenu extends QMenu
+{
+
+   /*******************************************************************************
+    ** Constructor that initializes the default view screen actions menu.
+    *******************************************************************************/
+   public QMenuDefaultViewScreenActionsMenu()
+   {
+      init();
+   }
+
+
+
+   /***************************************************************************
+    * Initializes the menu with its label, icon, and slot assignment.
+    *
+    * <p>Sets up the basic menu properties and then initializes the menu items.</p>
+    ***************************************************************************/
+   public void init()
+   {
+      withLabel("Actions");
+      withIcon(new QIcon("game"));
+      withSlot(QMenuSlot.VIEW_SCREEN_ACTIONS);
+
+      initItems();
+   }
+
+
+
+   /***************************************************************************
+    * Initializes the menu items structure.
+    *
+    * <p>Creates a menu structure with:</p>
+    * <ul>
+    *   <li>Header sub-list (New, Copy, Edit, Delete)</li>
+    *   <li>Divider</li>
+    *   <li>This table's process list</li>
+    *   <li>Divider</li>
+    *   <li>Footer sub-list (All tables process list, Developer Mode, Audit)</li>
+    * </ul>
+    ***************************************************************************/
+   public void initItems()
+   {
+      withItem(new HeaderSubList());
+      withItem(new QMenuItemDivider());
+      withItem(new QMenuItemBuiltIn(THIS_TABLE_PROCESS_LIST));
+      withItem(new QMenuItemDivider());
+      withItem(new FooterSubList());
+   }
+
+
+
+   /***************************************************************************
+    * Sub-list containing the header menu items (primary CRUD operations).
+    *
+    * <p>This nested class defines the standard header items that appear at
+    * the top of the default view screen actions menu: New, Copy, Edit, and Delete.</p>
+    ***************************************************************************/
+   public static class HeaderSubList extends QMenuItemSubList
+   {
+      /*******************************************************************************
+       ** Constructor that initializes the header sub-list.
+       *******************************************************************************/
+      public HeaderSubList()
+      {
+         init();
+      }
+
+
+
+      /***************************************************************************
+       * Initializes the sub-list structure.
+       ***************************************************************************/
+      public void init()
+      {
+         initItems();
+      }
+
+
+
+      /***************************************************************************
+       * Initializes the header menu items with standard CRUD operations.
+       ***************************************************************************/
+      public void initItems()
+      {
+         withItem(new QMenuItemBuiltIn(NEW).withLabel("New"));
+         withItem(new QMenuItemBuiltIn(COPY).withLabel("Copy"));
+         withItem(new QMenuItemBuiltIn(EDIT).withLabel("Edit"));
+         withItem(new QMenuItemBuiltIn(DELETE).withLabel("Delete"));
+      }
+   }
+
+
+
+   /***************************************************************************
+    * Sub-list containing the footer menu items (system-wide operations).
+    *
+    * <p>This nested class defines the standard footer items that appear at
+    * the bottom of the default view screen actions menu: process lists for all
+    * tables, Developer Mode, and Audit functionality.</p>
+    ***************************************************************************/
+   public static class FooterSubList extends QMenuItemSubList
+   {
+      /*******************************************************************************
+       ** Constructor that initializes the footer sub-list.
+       *******************************************************************************/
+      public FooterSubList()
+      {
+         init();
+      }
+
+
+
+      /***************************************************************************
+       * Initializes the sub-list structure.
+       ***************************************************************************/
+      public void init()
+      {
+         initItems();
+      }
+
+
+
+      /***************************************************************************
+       * Initializes the footer menu items with system-wide operations.
+       ***************************************************************************/
+      public void initItems()
+      {
+         withItem(new QMenuItemBuiltIn(ALL_TABLES_PROCESS_LIST));
+         withItem(new QMenuItemBuiltIn(DEVELOPER_MODE).withLabel("Developer Mode"));
+         withItem(new QMenuItemBuiltIn(AUDIT).withLabel("Audit"));
+      }
+   }
+
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemBase.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemBase.java
@@ -1,0 +1,144 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus.items;
+
+
+import com.kingsrook.qqq.backend.core.model.metadata.layout.QIcon;
+
+
+/*******************************************************************************
+ * abstract base class for menu items.  provides fields for basic methods
+ * required by the interface
+ *******************************************************************************/
+public abstract class QMenuItemBase implements QMenuItemInterface
+{
+   private String label;
+   private QIcon  icon;
+
+
+
+   /*******************************************************************************
+    * Getter for label
+    * @see #withLabel(String)
+    *******************************************************************************/
+   public String getLabel()
+   {
+      return (this.label);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for label
+    * @see #withLabel(String)
+    *******************************************************************************/
+   public void setLabel(String label)
+   {
+      this.label = label;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for label
+    *
+    * @param label
+    * user-facing text to display as the label for this menu item.  e.g., "New", "Copy",
+    * or "Process Orders".
+    * @return this
+    *******************************************************************************/
+   public QMenuItemBase withLabel(String label)
+   {
+      this.label = label;
+      return (this);
+   }
+
+
+
+   /***************************************************************************
+    * Creates and returns a shallow copy of this menu item.
+    *
+    * <p>The cloned item will have its own copy of the label and icon fields.
+    * Subclasses should override this method to provide deep cloning if they
+    * contain additional mutable state.</p>
+    *
+    * @return a clone of this menu item
+    * @throws RuntimeException if cloning is not supported (should not occur)
+    ***************************************************************************/
+   @Override
+   public QMenuItemBase clone()
+   {
+      try
+      {
+         QMenuItemBase clone = (QMenuItemBase) super.clone();
+         if(getIcon() != null)
+         {
+            clone.setIcon(getIcon().clone());
+         }
+
+         return clone;
+      }
+      catch(CloneNotSupportedException e)
+      {
+         throw new RuntimeException(e);
+      }
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for icon
+    * @see #withIcon(QIcon)
+    *******************************************************************************/
+   public QIcon getIcon()
+   {
+      return (this.icon);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for icon
+    * @see #withIcon(QIcon)
+    *******************************************************************************/
+   public void setIcon(QIcon icon)
+   {
+      this.icon = icon;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for icon
+    *
+    * @param icon
+    * Optional icon to display with this menu item.
+    *
+    * @return this
+    *******************************************************************************/
+   public QMenuItemBase withIcon(QIcon icon)
+   {
+      this.icon = icon;
+      return (this);
+   }
+
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemBuiltIn.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemBuiltIn.java
@@ -1,0 +1,243 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus.items;
+
+
+import java.io.Serializable;
+import java.util.Map;
+import com.kingsrook.qqq.backend.core.instances.QInstanceValidator;
+import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
+import com.kingsrook.qqq.backend.core.model.metadata.QMetaDataObject;
+import com.kingsrook.qqq.backend.core.utils.collections.MapBuilder;
+
+
+/*******************************************************************************
+ ** Menu item that represents a built-in action provided by the QQQ framework.
+ **
+ ** <p>Built-in menu items are standard actions that are implemented by the
+ ** framework itself, such as CRUD operations (New, Copy, Edit, Delete),
+ ** bulk operations, system functions (Developer Mode, Audit), and process lists.</p>
+ **
+ ** <p>These items are distinguished from custom menu items (like running
+ ** processes or downloading files) in that their behavior is predefined by
+ ** the framework and does not require additional configuration.</p>
+ **
+ ** @see DefaultOptions
+ *******************************************************************************/
+public class QMenuItemBuiltIn extends QMenuItemBase
+{
+
+   /***************************************************************************
+    * Interface marker for built-in option types.
+    *
+    * <p>This interface is implemented by enums that define available built-in
+    * options, such as {@link DefaultOptions}.</p>
+    ***************************************************************************/
+   public interface BuiltInOptionInterface extends Serializable
+   {
+   }
+
+
+
+   /***************************************************************************
+    * Enumeration of default built-in menu item options provided by QQQ.
+    *
+    * <p>These options represent standard actions that can be used in menus
+    * throughout a QQQ application. The options are grouped by category:</p>
+    * <ul>
+    *   <li>Single-record CRUD: NEW, COPY, EDIT, DELETE</li>
+    *   <li>Bulk operations: BULK_LOAD, BULK_EDIT, BULK_EDIT_WITH_FILE, BULK_DELETE</li>
+    *   <li>System functions: RUN_SCRIPT, DEVELOPER_MODE, AUDIT</li>
+    *   <li>Lists of QQQ Processes: THIS_TABLE_PROCESS_LIST, ALL_TABLES_PROCESS_LIST</li>
+    * </ul>
+    ***************************************************************************/
+   public enum DefaultOptions implements BuiltInOptionInterface
+   {
+      /** Create a new record. */
+      NEW,
+
+      /** Copy an existing record. */
+      COPY,
+
+      /** Edit the current record. */
+      EDIT,
+
+      /** Delete the current record. */
+      DELETE,
+
+      /** Bulk load records from a file. */
+      BULK_LOAD,
+
+      /** Bulk edit multiple records. */
+      BULK_EDIT,
+
+      /** Bulk edit multiple records using a file. */
+      BULK_EDIT_WITH_FILE,
+
+      /** Bulk delete multiple records. */
+      BULK_DELETE,
+
+      /** Run a script. */
+      RUN_SCRIPT,
+
+      /** Toggle developer mode. */
+      DEVELOPER_MODE,
+
+      /** View audit trail. */
+      AUDIT,
+
+      /** Display process list for the current table.  e.g.,
+       * {@link com.kingsrook.qqq.backend.core.model.metadata.processes.QProcessMetaData}
+       * objects whose tableName is the table being viewed. */
+      THIS_TABLE_PROCESS_LIST,
+
+      /** Display process list for generic processes which are enabled for all
+       *  tables, such as ScriptsMetaDataProvider.RUN_RECORD_SCRIPT_PROCESS_NAME */
+      ALL_TABLES_PROCESS_LIST
+   }
+
+
+
+   private BuiltInOptionInterface option;
+
+
+
+   /*******************************************************************************
+    ** Default constructor.
+    *******************************************************************************/
+   public QMenuItemBuiltIn()
+   {
+   }
+
+
+
+   /*******************************************************************************
+    ** Constructor that initializes the built-in option.
+    **
+    ** @param option the built-in option to use (e.g., DefaultOptions.NEW)
+    *******************************************************************************/
+   public QMenuItemBuiltIn(BuiltInOptionInterface option)
+   {
+      this.option = option;
+   }
+
+
+
+   /***************************************************************************
+    * Returns the item type identifier for built-in menu items.
+    *
+    * @return always returns "BUILT_IN"
+    ***************************************************************************/
+   @Override
+   public String getItemType()
+   {
+      return "BUILT_IN";
+   }
+
+
+
+   /***************************************************************************
+    * Returns the values map containing the built-in option.
+    *
+    * <p>The map contains a single entry with key "option" and the option value.</p>
+    *
+    * @return a map containing the built-in option
+    ***************************************************************************/
+   @Override
+   public Map<String, Serializable> getValues()
+   {
+      return MapBuilder.of("option", option);
+   }
+
+
+
+   /***************************************************************************
+    * Validates that the built-in menu item has a valid option configured.
+    *
+    * <p>Ensures that the option field is not null before the menu item can
+    * be used in a menu.</p>
+    *
+    * @param validator the validator instance to use for reporting errors
+    * @param qInstance the QQQ instance being validated
+    * @param parentObject the parent metadata object containing this menu item
+    ***************************************************************************/
+   @Override
+   public void validate(QInstanceValidator validator, QInstance qInstance, QMetaDataObject parentObject)
+   {
+      super.validate(validator, qInstance, parentObject);
+
+      validator.assertCondition(option != null, "Missing an option for menu item [" + getLabel() + "] in " + parentObject);
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for option
+    * @see #withOption(BuiltInOptionInterface)
+    *******************************************************************************/
+   public BuiltInOptionInterface getOption()
+   {
+      return (this.option);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for option
+    * @see #withOption(BuiltInOptionInterface)
+    *******************************************************************************/
+   public void setOption(BuiltInOptionInterface option)
+   {
+      this.option = option;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for option
+    *
+    * @param option
+    * Which built-in item to use
+    * @return this
+    *******************************************************************************/
+   public QMenuItemBuiltIn withOption(BuiltInOptionInterface option)
+   {
+      this.option = option;
+      return (this);
+   }
+
+
+
+   /***************************************************************************
+    * Creates and returns a shallow copy of this built-in menu item.
+    *
+    * @return a clone of this menu item
+    ***************************************************************************/
+   @Override
+   public QMenuItemBuiltIn clone()
+   {
+      QMenuItemBuiltIn clone = (QMenuItemBuiltIn) super.clone();
+
+      return clone;
+   }
+
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemDivider.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemDivider.java
@@ -1,0 +1,60 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus.items;
+
+
+/*******************************************************************************
+ ** Menu item that represents a visual divider or separator in a menu.
+ **
+ ** <p>Dividers are used to visually separate groups of menu items within
+ ** a menu structure. They typically render as horizontal lines or spacing
+ ** in the user interface.</p>
+ **
+ ** <p>Dividers do not have labels, icons, or any interactive behavior - they
+ ** are purely visual elements for menu organization.  Any settings from the
+ * base class that are populated in objects of this type will probably
+ * be ignored by any UI.</p>
+ *******************************************************************************/
+public class QMenuItemDivider extends QMenuItemBase
+{
+
+   /*******************************************************************************
+    ** Default constructor.
+    *******************************************************************************/
+   public QMenuItemDivider()
+   {
+   }
+
+
+
+   /***************************************************************************
+    * Returns the item type identifier for divider menu items.
+    *
+    * @return always returns "DIVIDER"
+    ***************************************************************************/
+   @Override
+   public String getItemType()
+   {
+      return ("DIVIDER");
+   }
+
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemDownloadFile.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemDownloadFile.java
@@ -1,0 +1,241 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus.items;
+
+
+import java.io.Serializable;
+import java.util.Map;
+import com.kingsrook.qqq.backend.core.context.QContext;
+import com.kingsrook.qqq.backend.core.instances.QInstanceValidator;
+import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
+import com.kingsrook.qqq.backend.core.model.metadata.QMetaDataObject;
+import com.kingsrook.qqq.backend.core.model.metadata.fields.QFieldMetaData;
+import com.kingsrook.qqq.backend.core.model.metadata.tables.QTableMetaData;
+import com.kingsrook.qqq.backend.core.utils.StringUtils;
+import com.kingsrook.qqq.backend.core.utils.collections.MapBuilder;
+
+
+/*******************************************************************************
+ ** Menu item that triggers a file download from a field in the current record.
+ **
+ ** <p>This menu item type is used to provide download functionality for
+ ** file fields (BLOB fields) or URL fields in a table. When selected, it
+ ** will download the file content from the specified field.</p>
+ **
+ ** <p>The label for this menu item can be automatically derived from the
+ ** field's metadata if not explicitly set.</p>
+ *******************************************************************************/
+public class QMenuItemDownloadFile extends QMenuItemBase
+{
+   private String fieldName;
+   private String tableName;
+
+
+
+   /*******************************************************************************
+    ** Default constructor.
+    *******************************************************************************/
+   public QMenuItemDownloadFile()
+   {
+   }
+
+
+
+   /*******************************************************************************
+    ** Constructor that initializes the download file item with a field name.
+    **
+    ** <p>This constructor assumes the field belongs to the table that contains
+    ** this menu item.</p>
+    **
+    ** @param fieldName the name of the field containing the file to download
+    *******************************************************************************/
+   public QMenuItemDownloadFile(String fieldName)
+   {
+      this(null, fieldName);
+   }
+
+
+
+   /*******************************************************************************
+    ** Constructor that initializes the download file item with a table and field name.
+    **
+    ** @param table the table metadata containing the field (can be null if field
+    **              is in the same table as the menu)
+    ** @param fieldName the name of the field containing the file to download
+    *******************************************************************************/
+   public QMenuItemDownloadFile(QTableMetaData table, String fieldName)
+   {
+      this.fieldName = fieldName;
+      this.tableName = table == null ? null : table.getName();
+   }
+
+
+
+   /***************************************************************************
+    * Returns the item type identifier for download file menu items.
+    *
+    * @return always returns "DOWNLOAD_FILE"
+    ***************************************************************************/
+   @Override
+   public String getItemType()
+   {
+      return ("DOWNLOAD_FILE");
+   }
+
+
+
+   /***************************************************************************
+    * Returns the values map containing the field name for the download.
+    *
+    * @return a map containing the field name under the key "fieldName"
+    ***************************************************************************/
+   @Override
+   public Map<String, Serializable> getValues()
+   {
+      return MapBuilder.of("fieldName", getFieldName());
+   }
+
+
+
+   /***************************************************************************
+    * Returns the label for this menu item, automatically deriving it from
+    * the field's metadata if not explicitly set.
+    *
+    * <p>If no label has been set on this menu item, this method attempts
+    * to retrieve the label from the field's metadata and sets it automatically.</p>
+    *
+    * @return the label for this menu item
+    ***************************************************************************/
+   @Override
+   public String getLabel()
+   {
+      ///////////////////////////////////////////////////////////////////////////////
+      // if a label hasn't been set here, try to get the field's label, and set it //
+      ///////////////////////////////////////////////////////////////////////////////
+      if(super.getLabel() == null && tableName != null && fieldName != null)
+      {
+         QInstance qInstance = QContext.getQInstance();
+         if(qInstance != null)
+         {
+            QTableMetaData table = qInstance.getTable(tableName);
+            if(table != null)
+            {
+               QFieldMetaData field = table.getField(fieldName);
+               if(field != null)
+               {
+                  setLabel(field.getLabel());
+               }
+            }
+         }
+      }
+
+      return super.getLabel();
+   }
+
+
+
+   /***************************************************************************
+    * Validates that the download file menu item has a valid field name and
+    * that the field exists in the table.
+    *
+    * <p>Ensures that:</p>
+    * <ul>
+    *   <li>A label is set (either explicitly or derived from the field)</li>
+    *   <li>A field name is specified</li>
+    *   <li>The field exists in the table (if parent is a QTableMetaData)</li>
+    * </ul>
+    *
+    * @param validator the validator instance to use for reporting errors
+    * @param qInstance the QQQ instance being validated
+    * @param parentObject the parent metadata object containing this menu item
+    ***************************************************************************/
+   @Override
+   public void validate(QInstanceValidator validator, QInstance qInstance, QMetaDataObject parentObject)
+   {
+      super.validate(validator, qInstance, parentObject);
+
+      validator.assertCondition(StringUtils.hasContent(getLabel()), "Missing a label for a menu item of type [" + getClass().getSimpleName() + "] for field [" + getFieldName() + "] in " + parentObject);
+
+      if(validator.assertCondition(StringUtils.hasContent(getFieldName()), "Missing a fieldName for menu item [" + getLabel() + "] in " + parentObject))
+      {
+         if(parentObject instanceof QTableMetaData table)
+         {
+            QFieldMetaData field = table.getFields().get(getFieldName());
+            validator.assertCondition(field != null, "Could not find field [" + getFieldName() + "], referenced in menu item [" + getLabel() + "] in " + parentObject);
+         }
+      }
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for fieldName
+    * @see #withFieldName(String)
+    *******************************************************************************/
+   public String getFieldName()
+   {
+      return (this.fieldName);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for fieldName
+    * @see #withFieldName(String)
+    *******************************************************************************/
+   public void setFieldName(String fieldName)
+   {
+      this.fieldName = fieldName;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for fieldName
+    *
+    * @param fieldName
+    * The field on the table holding this menu, that is either a BLOB, or a URL,
+    * which is what should be downloaded.
+    * @return this
+    *******************************************************************************/
+   public QMenuItemDownloadFile withFieldName(String fieldName)
+   {
+      this.fieldName = fieldName;
+      return (this);
+   }
+
+
+
+   /***************************************************************************
+    * Creates and returns a shallow copy of this download file menu item.
+    *
+    * @return a clone of this menu item
+    ***************************************************************************/
+   @Override
+   public QMenuItemDownloadFile clone()
+   {
+      QMenuItemDownloadFile clone = (QMenuItemDownloadFile) super.clone();
+
+      return clone;
+   }
+
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemInterface.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemInterface.java
@@ -1,0 +1,83 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus.items;
+
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+import com.kingsrook.qqq.backend.core.instances.QInstanceValidator;
+import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
+import com.kingsrook.qqq.backend.core.model.metadata.QMetaDataObject;
+import com.kingsrook.qqq.backend.core.model.metadata.layout.QIcon;
+import com.kingsrook.qqq.backend.core.utils.StringUtils;
+
+
+/*******************************************************************************
+ ** interface for different types of menu items.
+ *******************************************************************************/
+public interface QMenuItemInterface extends QMetaDataObject, Cloneable
+{
+   /***************************************************************************
+    * returns user-facing text to display as the label for this menu item.  e.g.,
+    * "New", "Copy", or "Process Orders".
+    ***************************************************************************/
+   String getLabel();
+
+   /***************************************************************************
+    * Optional icon to display with this menu item.  Frontends may choose to
+    * use a default if no icon is given.
+    ***************************************************************************/
+   QIcon getIcon();
+
+   /***************************************************************************
+    * Specify the "type" of menu item - e.g., what sub-class it is, but more
+    * accurately, instructions to the frontend on how to handle the item.
+    ***************************************************************************/
+   String getItemType();
+
+   /***************************************************************************
+    * get the values associated with this specific menu item.
+    *
+    * <p>For example, for a run-process item, the name of the process.</p>
+    ***************************************************************************/
+   default Map<String, Serializable> getValues()
+   {
+      return (Collections.emptyMap());
+   }
+
+   /***************************************************************************
+    * As part of QInstanceValidation, verify that the meta-data in this object
+    * is all fully valid.
+    *
+    * <p>Subclasses should generally include a call to super.validate</p>
+    ***************************************************************************/
+   default void validate(QInstanceValidator validator, QInstance qInstance, QMetaDataObject parentObject)
+   {
+      validator.assertCondition(StringUtils.hasContent(getItemType()), "Missing an itemType for menu item [" + getLabel() + "] in " + parentObject);
+   }
+
+   /***************************************************************************
+    *
+    ***************************************************************************/
+   QMenuItemInterface clone();
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemRunProcess.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemRunProcess.java
@@ -1,0 +1,257 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus.items;
+
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+import com.kingsrook.qqq.backend.core.context.QContext;
+import com.kingsrook.qqq.backend.core.instances.QInstanceValidator;
+import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
+import com.kingsrook.qqq.backend.core.model.metadata.QMetaDataObject;
+import com.kingsrook.qqq.backend.core.model.metadata.layout.QIcon;
+import com.kingsrook.qqq.backend.core.model.metadata.processes.QProcessMetaData;
+import com.kingsrook.qqq.backend.core.model.metadata.tables.QTableMetaData;
+import com.kingsrook.qqq.backend.core.utils.StringUtils;
+import com.kingsrook.qqq.backend.core.utils.collections.MapBuilder;
+
+
+/*******************************************************************************
+ ** Menu item that triggers the execution of a QQQ process.
+ **
+ ** <p>This menu item type is used to provide menu-driven access to processes
+ ** defined in the QQQ application. When selected, it will execute the specified
+ ** process.</p>
+ **
+ ** <p>The label and icon for this menu item can be automatically derived from
+ ** the process's metadata if not explicitly set.</p>
+ **
+ ** <p>The process must be associated with the same table that contains this
+ ** menu item.</p>
+ *******************************************************************************/
+public class QMenuItemRunProcess extends QMenuItemBase
+{
+   private String processName;
+
+
+
+   /*******************************************************************************
+    ** Default constructor.
+    *******************************************************************************/
+   public QMenuItemRunProcess()
+   {
+   }
+
+
+
+   /*******************************************************************************
+    ** Constructor that initializes the run process item with a process name.
+    **
+    ** @param processName the name of the process to execute
+    *******************************************************************************/
+   public QMenuItemRunProcess(String processName)
+   {
+      this.processName = processName;
+   }
+
+
+
+   /***************************************************************************
+    * Returns the label for this menu item, automatically deriving it from
+    * the process's metadata if not explicitly set.
+    *
+    * <p>If no label has been set on this menu item, this method attempts
+    * to retrieve the label from the process's metadata and sets it automatically.</p>
+    *
+    * @return the label for this menu item
+    ***************************************************************************/
+   @Override
+   public String getLabel()
+   {
+      //////////////////////////////////////////////////////////////////////////////////////////
+      // if a label hasn't been set here, try to get the process's label, and set it in here. //
+      //////////////////////////////////////////////////////////////////////////////////////////
+      if(super.getLabel() == null)
+      {
+         QInstance qInstance = QContext.getQInstance();
+         if(qInstance != null)
+         {
+            QProcessMetaData process = qInstance.getProcess(processName);
+            if(process != null)
+            {
+               setLabel(process.getLabel());
+            }
+         }
+      }
+
+      return super.getLabel();
+   }
+
+
+
+   /***************************************************************************
+    * Returns the icon for this menu item, automatically deriving it from
+    * the process's metadata if not explicitly set.
+    *
+    * <p>If no icon has been set on this menu item, this method attempts
+    * to retrieve the icon from the process's metadata and sets it automatically.</p>
+    *
+    * @return the icon for this menu item, or null if none is available
+    ***************************************************************************/
+   @Override
+   public QIcon getIcon()
+   {
+      /////////////////////////////////////////////////////////////////////////////////////////
+      // if an icon hasn't been set here, try to get the process's icon, and set it in here. //
+      /////////////////////////////////////////////////////////////////////////////////////////
+      if(super.getIcon() == null)
+      {
+         QInstance qInstance = QContext.getQInstance();
+         if(qInstance != null)
+         {
+            QProcessMetaData process = qInstance.getProcess(processName);
+            if(process != null)
+            {
+               setIcon(process.getIcon());
+            }
+         }
+      }
+
+      return super.getIcon();
+   }
+
+
+
+   /***************************************************************************
+    * Returns the item type identifier for run process menu items.
+    *
+    * @return always returns "RUN_PROCESS"
+    ***************************************************************************/
+   @Override
+   public String getItemType()
+   {
+      return ("RUN_PROCESS");
+   }
+
+
+
+   /***************************************************************************
+    * Returns the values map containing the process name.
+    *
+    * @return a map containing the process name under the key "processName"
+    ***************************************************************************/
+   @Override
+   public Map<String, Serializable> getValues()
+   {
+      return MapBuilder.of("processName", getProcessName());
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for processName
+    * @see #withProcessName(String)
+    *******************************************************************************/
+   public String getProcessName()
+   {
+      return (this.processName);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for processName
+    * @see #withProcessName(String)
+    *******************************************************************************/
+   public void setProcessName(String processName)
+   {
+      this.processName = processName;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for processName
+    *
+    * @param processName
+    * The name of the process to run.  Required to be a valid process in the instance,
+    * and associated with the table in which this menu item is defined (via process.tableName).
+    * @return this
+    *******************************************************************************/
+   public QMenuItemRunProcess withProcessName(String processName)
+   {
+      this.processName = processName;
+      return (this);
+   }
+
+
+
+   /***************************************************************************
+    * Validates that the run process menu item has a valid process name and
+    * that the process exists and is associated with the correct table.
+    *
+    * <p>Ensures that:</p>
+    * <ul>
+    *   <li>A process name is specified</li>
+    *   <li>The process exists in the QQQ instance</li>
+    *   <li>The process is associated with the same table as the menu item
+    *       (if parent is a QTableMetaData)</li>
+    * </ul>
+    *
+    * @param validator the validator instance to use for reporting errors
+    * @param qInstance the QQQ instance being validated
+    * @param parentObject the parent metadata object containing this menu item
+    ***************************************************************************/
+   @Override
+   public void validate(QInstanceValidator validator, QInstance qInstance, QMetaDataObject parentObject)
+   {
+      super.validate(validator, qInstance, parentObject);
+
+      if(validator.assertCondition(StringUtils.hasContent(getProcessName()), "Missing a processName for menu item [" + getLabel() + "] in " + parentObject))
+      {
+         QProcessMetaData process = qInstance.getProcess(getProcessName());
+         if(validator.assertCondition(process != null, "Could not find process [" + getProcessName() + "], referenced in menu item [" + getLabel() + "] in " + parentObject))
+         {
+            if(parentObject instanceof QTableMetaData table)
+            {
+               validator.assertCondition(Objects.equals(table.getName(), process.getTableName()), "Process [" + getProcessName() + "] is not associated with table [" + table.getName() + "] in menu item [" + getLabel() + "] in " + parentObject);
+            }
+         }
+      }
+   }
+
+
+
+   /***************************************************************************
+    * Creates and returns a shallow copy of this run process menu item.
+    *
+    * @return a clone of this menu item
+    ***************************************************************************/
+   @Override
+   public QMenuItemRunProcess clone()
+   {
+      QMenuItemRunProcess clone = (QMenuItemRunProcess) super.clone();
+
+      return clone;
+   }
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemSubList.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemSubList.java
@@ -1,0 +1,191 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus.items;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import com.google.gson.reflect.TypeToken;
+import com.kingsrook.qqq.backend.core.instances.QInstanceValidator;
+import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
+import com.kingsrook.qqq.backend.core.model.metadata.QMetaDataObject;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.QMenuItemContainerInterface;
+import com.kingsrook.qqq.backend.core.utils.CollectionUtils;
+import com.kingsrook.qqq.backend.core.utils.collections.MapBuilder;
+
+
+/*******************************************************************************
+ ** Menu item that contains a sub-list of other menu items.
+ **
+ ** <p>Sub-lists are used to group related menu items together within a menu.
+ ** They differ from sub-menus in that they typically render as a flat list
+ ** rather than a nested menu structure. Sub-lists are useful for organizing
+ ** items that belong together logically but should appear inline rather than
+ ** in a separate menu - from the user point of view, sublists are invisible.
+ ** They are only visible to developers.</p>
+ **
+ ** <p>This class implements {@link QMenuItemContainerInterface} to allow
+ ** it to contain other menu items.</p>
+ **
+ ** @see QMenuItemSubMenu
+ ** @see QMenuItemContainerInterface
+ *******************************************************************************/
+public class QMenuItemSubList extends QMenuItemBase implements QMenuItemContainerInterface
+{
+   private ArrayList<QMenuItemInterface> items;
+
+
+
+   /***************************************************************************
+    * Returns the item type identifier for sub-list menu items.
+    *
+    * @return always returns "SUB_LIST"
+    ***************************************************************************/
+   @Override
+   public String getItemType()
+   {
+      return "SUB_LIST";
+   }
+
+
+
+   /***************************************************************************
+    * Returns the values map containing the list of items in this sub-list.
+    *
+    * @return a map containing the items list under the key "items"
+    ***************************************************************************/
+   @Override
+   public Map<String, Serializable> getValues()
+   {
+      return MapBuilder.of("items", items);
+   }
+
+
+
+   /***************************************************************************
+    * Validates all menu items contained within this sub-list.
+    *
+    * <p>Recursively validates each item in the sub-list, passing this sub-list
+    * as the parent object for validation context.</p>
+    *
+    * @param validator the validator instance to use for reporting errors
+    * @param qInstance the QQQ instance being validated
+    * @param parentObject the parent metadata object containing this sub-list
+    ***************************************************************************/
+   @Override
+   public void validate(QInstanceValidator validator, QInstance qInstance, QMetaDataObject parentObject)
+   {
+      super.validate(validator, qInstance, parentObject);
+
+      for(QMenuItemInterface qMenuItemInterface : CollectionUtils.nonNullList(items))
+      {
+         qMenuItemInterface.validate(validator, qInstance, this);
+      }
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for items
+    * @see #withItems(List)
+    *******************************************************************************/
+   public List<QMenuItemInterface> getItems()
+   {
+      return (this.items);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for items
+    * @see #withItems(List)
+    *******************************************************************************/
+   public void setItems(List<QMenuItemInterface> items)
+   {
+      this.items = CollectionUtils.useOrWrap(items, new TypeToken<>() {});
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for items
+    *
+    * @param items
+    * Contents of the sub list
+    * @return this
+    *******************************************************************************/
+   public QMenuItemSubList withItems(List<QMenuItemInterface> items)
+   {
+      setItems(items);
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Fluently add a single item
+    *
+    * @param item
+    * one item to add to this sub list
+    * @return this
+    *******************************************************************************/
+   public QMenuItemSubList withItem(QMenuItemInterface item)
+   {
+      if(this.items == null)
+      {
+         this.items = new ArrayList<>();
+      }
+      this.items.add(item);
+      return (this);
+   }
+
+
+
+   /***************************************************************************
+    * Creates and returns a deep copy of this sub-list menu item.
+    *
+    * <p>The cloned sub-list will have its own copy of the items list, with
+    * each item also being cloned. This ensures that modifications to the
+    * cloned sub-list or its items will not affect the original.</p>
+    *
+    * @return a deep clone of this sub-list menu item
+    ***************************************************************************/
+   @Override
+   public QMenuItemSubList clone()
+   {
+      QMenuItemSubList clone = (QMenuItemSubList) super.clone();
+
+      if(items != null)
+      {
+         ArrayList<QMenuItemInterface> cloneItems = new ArrayList<>();
+         for(QMenuItemInterface item : items)
+         {
+            cloneItems.add(item.clone());
+         }
+         clone.setItems(cloneItems);
+      }
+
+      return clone;
+   }
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemSubMenu.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemSubMenu.java
@@ -1,0 +1,222 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus.items;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import com.google.gson.reflect.TypeToken;
+import com.kingsrook.qqq.backend.core.instances.QInstanceValidator;
+import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
+import com.kingsrook.qqq.backend.core.model.metadata.QMetaDataObject;
+import com.kingsrook.qqq.backend.core.model.metadata.layout.QIcon;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.QMenuItemContainerInterface;
+import com.kingsrook.qqq.backend.core.utils.CollectionUtils;
+import com.kingsrook.qqq.backend.core.utils.collections.MapBuilder;
+
+
+/*******************************************************************************
+ ** Menu item that contains a nested sub-menu of other menu items.
+ **
+ ** <p>Sub-menus are used to create hierarchical menu structures. They differ
+ ** from sub-lists in that they typically render as a nested menu that opens
+ ** when selected, rather than displaying items inline. Sub-menus are useful
+ ** for organizing large numbers of menu items into logical groups for users
+ ** to see.</p>
+ **
+ ** <p>This class implements {@link QMenuItemContainerInterface} to allow
+ ** it to contain other menu items. Sub-menus can have their own label and
+ ** icon, which are displayed in the parent menu.</p>
+ **
+ ** @see QMenuItemSubList
+ ** @see QMenuItemContainerInterface
+ *******************************************************************************/
+public class QMenuItemSubMenu extends QMenuItemBase implements QMenuItemContainerInterface
+{
+   private ArrayList<QMenuItemInterface> items;
+
+
+
+   /***************************************************************************
+    * Returns the item type identifier for sub-menu menu items.
+    *
+    * @return always returns "SUB_MENU"
+    ***************************************************************************/
+   @Override
+   public String getItemType()
+   {
+      return "SUB_MENU";
+   }
+
+
+
+   /***************************************************************************
+    * Returns the values map containing the list of items in this sub-menu.
+    *
+    * @return a map containing the items list under the key "items"
+    ***************************************************************************/
+   @Override
+   public Map<String, Serializable> getValues()
+   {
+      return MapBuilder.of("items", items);
+   }
+
+
+
+   /***************************************************************************
+    * Validates all menu items contained within this sub-menu.
+    *
+    * <p>Recursively validates each item in the sub-menu, passing this sub-menu
+    * as the parent object for validation context.</p>
+    *
+    * @param validator the validator instance to use for reporting errors
+    * @param qInstance the QQQ instance being validated
+    * @param parentObject the parent metadata object containing this sub-menu
+    ***************************************************************************/
+   @Override
+   public void validate(QInstanceValidator validator, QInstance qInstance, QMetaDataObject parentObject)
+   {
+      super.validate(validator, qInstance, parentObject);
+
+      for(QMenuItemInterface qMenuItemInterface : CollectionUtils.nonNullList(items))
+      {
+         qMenuItemInterface.validate(validator, qInstance, this);
+      }
+   }
+
+
+
+   /***************************************************************************
+    * Fluent setter for label that returns this sub-menu for method chaining.
+    *
+    * @param label user-facing text to display as the label for this sub-menu
+    * @return this sub-menu instance
+    ***************************************************************************/
+   @Override
+   public QMenuItemSubMenu withLabel(String label)
+   {
+      super.withLabel(label);
+      return this;
+   }
+
+
+
+   /***************************************************************************
+    * Fluent setter for icon that returns this sub-menu for method chaining.
+    *
+    * @param icon optional icon to display with this sub-menu
+    * @return this sub-menu instance
+    ***************************************************************************/
+   @Override
+   public QMenuItemSubMenu withIcon(QIcon icon)
+   {
+      super.withIcon(icon);
+      return this;
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for items
+    * @see #withItems(List)
+    *******************************************************************************/
+   public List<QMenuItemInterface> getItems()
+   {
+      return (this.items);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for items
+    * @see #withItems(List)
+    *******************************************************************************/
+   public void setItems(List<QMenuItemInterface> items)
+   {
+      this.items = CollectionUtils.useOrWrap(items, new TypeToken<>() {});
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for items
+    *
+    * @param items
+    * Contents of the sub Menu
+    * @return this
+    *******************************************************************************/
+   public QMenuItemSubMenu withItems(List<QMenuItemInterface> items)
+   {
+      setItems(items);
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Fluently add a single item
+    *
+    * @param item
+    * one item to add to this sub Menu
+    * @return this
+    *******************************************************************************/
+   public QMenuItemSubMenu withItem(QMenuItemInterface item)
+   {
+      if(this.items == null)
+      {
+         this.items = new ArrayList<>();
+      }
+      this.items.add(item);
+      return (this);
+   }
+
+
+
+   /***************************************************************************
+    * Creates and returns a deep copy of this sub-menu menu item.
+    *
+    * <p>The cloned sub-menu will have its own copy of the items list, with
+    * each item also being cloned. This ensures that modifications to the
+    * cloned sub-menu or its items will not affect the original.</p>
+    *
+    * @return a deep clone of this sub-menu menu item
+    ***************************************************************************/
+   @Override
+   public QMenuItemSubList clone()
+   {
+      QMenuItemSubList clone = (QMenuItemSubList) super.clone();
+
+      if(items != null)
+      {
+         ArrayList<QMenuItemInterface> cloneItems = new ArrayList<>();
+         for(QMenuItemInterface item : items)
+         {
+            cloneItems.add(item.clone());
+         }
+         clone.setItems(cloneItems);
+      }
+
+      return clone;
+   }
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/tables/QTableMetaData.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/tables/QTableMetaData.java
@@ -49,6 +49,7 @@ import com.kingsrook.qqq.backend.core.model.metadata.help.HelpRole;
 import com.kingsrook.qqq.backend.core.model.metadata.help.QHelpContent;
 import com.kingsrook.qqq.backend.core.model.metadata.layout.QAppChildMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.layout.QIcon;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.QMenu;
 import com.kingsrook.qqq.backend.core.model.metadata.permissions.MetaDataWithPermissionRules;
 import com.kingsrook.qqq.backend.core.model.metadata.permissions.QPermissionRules;
 import com.kingsrook.qqq.backend.core.model.metadata.qbits.SourceQBitAware;
@@ -113,6 +114,8 @@ public class QTableMetaData implements QAppChildMetaData, Serializable, MetaData
    private ShareableTableMetaData shareableTableMetaData;
 
    protected Map<String, List<QHelpContent>> helpContent;
+
+   private List<QMenu> menus;
 
 
 
@@ -1854,6 +1857,16 @@ public class QTableMetaData implements QAppChildMetaData, Serializable, MetaData
             clone.setHelpContent(clonedHelpContent);
          }
 
+         if(menus != null)
+         {
+            List<QMenu> clonedMenus = new ArrayList<>();
+            for(QMenu menu : menus)
+            {
+               clonedMenus.add(menu.clone());
+            }
+            clone.setMenus(clonedMenus);
+         }
+
          return clone;
       }
       catch(CloneNotSupportedException e)
@@ -1902,6 +1915,62 @@ public class QTableMetaData implements QAppChildMetaData, Serializable, MetaData
    public QTableMetaData withVirtualFields(Map<String, QVirtualFieldMetaData> virtualFields)
    {
       this.virtualFields = virtualFields;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for menus
+    * @see #withMenus(List)
+    *******************************************************************************/
+   public List<QMenu> getMenus()
+   {
+      return (this.menus);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for menus
+    * @see #withMenus(List)
+    *******************************************************************************/
+   public void setMenus(List<QMenu> menus)
+   {
+      this.menus = menus;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for menus
+    *
+    * @param menus
+    * Specialized menus to be used for this table in UI's.
+    * @return this
+    *******************************************************************************/
+   public QTableMetaData withMenus(List<QMenu> menus)
+   {
+      this.menus = menus;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Fluently add a single menu
+    *
+    * @param menu
+    * A Specialized menu to be used for this table in UI's.
+    * @return this
+    *******************************************************************************/
+   public QTableMetaData withMenu(QMenu menu)
+   {
+      if(this.menus == null)
+      {
+         this.menus = new ArrayList<>();
+      }
+      this.menus.add(menu);
       return (this);
    }
 

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/instances/QInstanceValidatorTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/instances/QInstanceValidatorTest.java
@@ -79,6 +79,10 @@ import com.kingsrook.qqq.backend.core.model.metadata.joins.QJoinMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.layout.QAppMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.layout.QAppSection;
 import com.kingsrook.qqq.backend.core.model.metadata.layout.QIcon;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.QMenu;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.QMenuSlot;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.defaults.QMenuDefaultViewScreenActionsMenu;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemRunProcess;
 import com.kingsrook.qqq.backend.core.model.metadata.possiblevalues.QPossibleValue;
 import com.kingsrook.qqq.backend.core.model.metadata.possiblevalues.QPossibleValueSource;
 import com.kingsrook.qqq.backend.core.model.metadata.possiblevalues.QPossibleValueSourceType;
@@ -1748,6 +1752,44 @@ public class QInstanceValidatorTest extends BaseTest
    {
       assertValidationSuccess((qInstance) -> qInstance.getTable(TestUtils.TABLE_NAME_PERSON_MEMORY)
          .withUniqueKey(new UniqueKey().withFieldName("id")));
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testTableMenus()
+   {
+      ///////////////////////////////////////////
+      // the view screen default menu is valid //
+      ///////////////////////////////////////////
+      assertValidationSuccess((qInstance) -> qInstance.getTable(TestUtils.TABLE_NAME_PERSON_MEMORY)
+         .withMenu(new QMenuDefaultViewScreenActionsMenu()));
+
+      ///////////////////////////////////////////////
+      // an empty menu fails - it's missing a slot //
+      ///////////////////////////////////////////////
+      assertValidationFailureReasons((qInstance) -> qInstance.getTable(TestUtils.TABLE_NAME_PERSON_MEMORY)
+            .withMenu(new QMenu()),
+         "Missing a slot for menu item [null] in QTableMetaData[personMemory]");
+
+      //////////////////////////////////
+      // a menu with a bad item fails //
+      //////////////////////////////////
+      assertValidationFailureReasons((qInstance) -> qInstance.getTable(TestUtils.TABLE_NAME_PERSON_MEMORY)
+            .withMenu(new QMenu().withSlot(QMenuSlot.VIEW_SCREEN_ADDITIONAL)
+               .withItem(new QMenuItemRunProcess())),
+         "Missing a processName for menu item [null] in QTableMetaData[personMemory]");
+
+      ////////////////////////////////////
+      // a menu with a good item passes //
+      ////////////////////////////////////
+      assertValidationSuccess((qInstance) -> qInstance.getTable(TestUtils.TABLE_NAME_PERSON_MEMORY)
+         .withMenu(new QMenu().withSlot(QMenuSlot.VIEW_SCREEN_ADDITIONAL)
+            .withItem(new QMenuItemRunProcess(TestUtils.PROCESS_NAME_INCREASE_BIRTHDATE))));
+
    }
 
 

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/metadata/menus/adjusters/QMenuAdjusterTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/metadata/menus/adjusters/QMenuAdjusterTest.java
@@ -1,0 +1,393 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus.adjusters;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import com.kingsrook.qqq.backend.core.BaseTest;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.QCriteriaOperator;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.defaults.QMenuDefaultViewScreenActionsMenu;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemBase;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemBuiltIn;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemDivider;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemInterface;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemSubList;
+import com.kingsrook.qqq.backend.core.model.metadata.menus.items.QMenuItemSubMenu;
+import com.kingsrook.qqq.backend.core.utils.CollectionUtils;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/*******************************************************************************
+ ** Unit test for QMenuAdjuster 
+ *******************************************************************************/
+class QMenuAdjusterTest extends BaseTest
+{
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testRemovingBuiltInOptions()
+   {
+      QMenuDefaultViewScreenActionsMenu menu = new QMenuDefaultViewScreenActionsMenu();
+
+      //////////////////////////////////////////
+      // this option is in the top-level list //
+      //////////////////////////////////////////
+      assertTrue(doesMenuHaveBuiltInOption(menu.getItems(), QMenuItemBuiltIn.DefaultOptions.THIS_TABLE_PROCESS_LIST));
+      assertTrue(QMenuAdjuster.removeFirst(menu, new QMenuItemMatcher(QMenuItemBuiltIn.DefaultOptions.THIS_TABLE_PROCESS_LIST)));
+      assertFalse(doesMenuHaveBuiltInOption(menu.getItems(), QMenuItemBuiltIn.DefaultOptions.THIS_TABLE_PROCESS_LIST));
+
+      //////////////////////////////////
+      // this option is in a sub list //
+      //////////////////////////////////
+      assertTrue(doesMenuHaveBuiltInOption(menu.getItems(), QMenuItemBuiltIn.DefaultOptions.NEW));
+      assertTrue(QMenuAdjuster.removeFirst(menu, new QMenuItemMatcher(QMenuItemBuiltIn.DefaultOptions.NEW)));
+      assertFalse(doesMenuHaveBuiltInOption(menu.getItems(), QMenuItemBuiltIn.DefaultOptions.NEW));
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testNoFailureIfRemoveDoesntMatch()
+   {
+      QMenuDefaultViewScreenActionsMenu menu = new QMenuDefaultViewScreenActionsMenu();
+
+      //////////////////////////////////////////////////////////////
+      // a built-in that isn't in the menu shouldn't be a problem //
+      //////////////////////////////////////////////////////////////
+      assertFalse(doesMenuHaveBuiltInOption(menu.getItems(), CustomBuiltInOptions.RED));
+      assertFalse(QMenuAdjuster.removeFirst(menu, new QMenuItemMatcher(CustomBuiltInOptions.RED)));
+      assertFalse(doesMenuHaveBuiltInOption(menu.getItems(), CustomBuiltInOptions.RED));
+
+      ///////////////////////////////////////////////////////////////
+      // a class that isn't in the menu should not cause a failure //
+      ///////////////////////////////////////////////////////////////
+      Class<CustomMenuItem> customMenuItemClass = CustomMenuItem.class;
+      assertFalse(doesMenuHaveItemOfType(menu.getItems(), customMenuItemClass));
+      assertFalse(QMenuAdjuster.removeFirst(menu, new QMenuItemMatcher(customMenuItemClass)));
+      assertFalse(doesMenuHaveItemOfType(menu.getItems(), customMenuItemClass));
+
+      ///////////////////////////////////////////////////
+      // a label that isn't in the menu should be fine //
+      ///////////////////////////////////////////////////
+      String label = "Foobar";
+      assertFalse(doesMenuHaveItemWithLabel(menu.getItems(), label));
+      assertFalse(QMenuAdjuster.removeFirst(menu, new QMenuItemMatcher(QCriteriaOperator.EQUALS, label)));
+      assertFalse(doesMenuHaveItemWithLabel(menu.getItems(), label));
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testRemovingByClass()
+   {
+      QMenuDefaultViewScreenActionsMenu menu = new QMenuDefaultViewScreenActionsMenu();
+
+      Class<QMenuDefaultViewScreenActionsMenu.FooterSubList> footerSubListClass = QMenuDefaultViewScreenActionsMenu.FooterSubList.class;
+      assertTrue(doesMenuHaveItemOfType(menu.getItems(), footerSubListClass));
+      assertTrue(QMenuAdjuster.removeFirst(menu, new QMenuItemMatcher(footerSubListClass)));
+      assertFalse(doesMenuHaveItemOfType(menu.getItems(), footerSubListClass));
+
+      /////////////////////////////////////////////////////////////////////////////
+      // there are two dividers - first remove them one-by-one with remove-first //
+      /////////////////////////////////////////////////////////////////////////////
+      Class<QMenuItemDivider> dividerClass = QMenuItemDivider.class;
+      assertTrue(doesMenuHaveItemOfType(menu.getItems(), dividerClass));
+      assertTrue(QMenuAdjuster.removeFirst(menu, new QMenuItemMatcher(dividerClass)));
+      assertTrue(doesMenuHaveItemOfType(menu.getItems(), dividerClass));
+      assertTrue(QMenuAdjuster.removeFirst(menu, new QMenuItemMatcher(dividerClass)));
+      assertFalse(doesMenuHaveItemOfType(menu.getItems(), dividerClass));
+
+      //////////////////////////////////////////////////////
+      // now do them both at the same time with removeAll //
+      //////////////////////////////////////////////////////
+      menu = new QMenuDefaultViewScreenActionsMenu();
+      assertTrue(doesMenuHaveItemOfType(menu.getItems(), dividerClass));
+      assertEquals(2, QMenuAdjuster.removeAll(menu, new QMenuItemMatcher(dividerClass)));
+      assertFalse(doesMenuHaveItemOfType(menu.getItems(), dividerClass));
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testRemovingByLabel()
+   {
+      QMenuDefaultViewScreenActionsMenu menu = new QMenuDefaultViewScreenActionsMenu();
+
+      assertTrue(doesMenuHaveItemWithLabel(menu.getItems(), "Copy"));
+      assertTrue(QMenuAdjuster.removeFirst(menu, new QMenuItemMatcher(QCriteriaOperator.EQUALS, "Copy")));
+      assertFalse(doesMenuHaveItemWithLabel(menu.getItems(), "Copy"));
+
+      ///////////////////////////////////////////
+      // there are two that start with "De"... //
+      ///////////////////////////////////////////
+      assertTrue(doesMenuHaveItemWithLabel(menu.getItems(), "Delete"));
+      assertTrue(doesMenuHaveItemWithLabel(menu.getItems(), "Developer Mode"));
+      assertEquals(2, QMenuAdjuster.removeAll(menu, new QMenuItemMatcher(QCriteriaOperator.STARTS_WITH, "De")));
+      assertFalse(doesMenuHaveItemWithLabel(menu.getItems(), "Delete"));
+      assertFalse(doesMenuHaveItemWithLabel(menu.getItems(), "Developer Mode"));
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testAdding()
+   {
+      ////////////////////////////////////////////////////////////////////
+      // add after the first item (NEW)                                 //
+      // note, NEW is in a sub-list, so it comes back as index 1, not 0 //
+      ////////////////////////////////////////////////////////////////////
+      {
+         QMenuDefaultViewScreenActionsMenu menu = new QMenuDefaultViewScreenActionsMenu();
+         QMenuAdjuster.addAfter(menu, new CustomMenuItem(), new QMenuItemMatcher(QMenuItemBuiltIn.DefaultOptions.NEW));
+         List<QMenuItemInterface> flatItems = flattenItems(menu.getItems());
+         assertEquals("New", flatItems.get(1).getLabel());
+         assertEquals("Custom", flatItems.get(2).getLabel());
+      }
+
+      /////////////////////////////////////
+      // add before the first item (NEW) //
+      /////////////////////////////////////
+      {
+         QMenuDefaultViewScreenActionsMenu menu = new QMenuDefaultViewScreenActionsMenu();
+         QMenuAdjuster.addBefore(menu, new CustomMenuItem(), new QMenuItemMatcher(QMenuItemBuiltIn.DefaultOptions.NEW));
+         List<QMenuItemInterface> flatItems = flattenItems(menu.getItems());
+         assertEquals("Custom", flatItems.get(1).getLabel());
+         assertEquals("New", flatItems.get(2).getLabel());
+      }
+
+      /////////////////////////////////////////////////////////
+      // now add after the true first item (the header list) //
+      /////////////////////////////////////////////////////////
+      {
+         QMenuDefaultViewScreenActionsMenu menu = new QMenuDefaultViewScreenActionsMenu();
+         QMenuAdjuster.addAfter(menu, new CustomMenuItem(), new QMenuItemMatcher(QMenuDefaultViewScreenActionsMenu.HeaderSubList.class));
+         assertEquals(QMenuDefaultViewScreenActionsMenu.HeaderSubList.class, menu.getItems().get(0).getClass());
+         assertEquals("Custom", menu.getItems().get(1).getLabel());
+      }
+
+      /////////////////////////////////////////////
+      // add before the first item (header list) //
+      /////////////////////////////////////////////
+      {
+         QMenuDefaultViewScreenActionsMenu menu = new QMenuDefaultViewScreenActionsMenu();
+         QMenuAdjuster.addBefore(menu, new CustomMenuItem(), new QMenuItemMatcher(QMenuDefaultViewScreenActionsMenu.HeaderSubList.class));
+         assertEquals("Custom", menu.getItems().get(0).getLabel());
+         assertEquals(QMenuDefaultViewScreenActionsMenu.HeaderSubList.class, menu.getItems().get(1).getClass());
+      }
+
+      //////////////////////////////////////////////////////////////////
+      // do before and after the last item in the footer list (audit) //
+      //////////////////////////////////////////////////////////////////
+      {
+         QMenuDefaultViewScreenActionsMenu menu = new QMenuDefaultViewScreenActionsMenu();
+         QMenuAdjuster.addAfter(menu, new CustomMenuItem(), new QMenuItemMatcher(QMenuItemBuiltIn.DefaultOptions.AUDIT));
+         List<QMenuItemInterface> flatItems = flattenItems(menu.getItems());
+         assertEquals("Audit", flatItems.get(flatItems.size() - 2).getLabel());
+         assertEquals("Custom", flatItems.get(flatItems.size() - 1).getLabel());
+      }
+      {
+         QMenuDefaultViewScreenActionsMenu menu = new QMenuDefaultViewScreenActionsMenu();
+         QMenuAdjuster.addBefore(menu, new CustomMenuItem(), new QMenuItemMatcher(QMenuItemBuiltIn.DefaultOptions.AUDIT));
+         List<QMenuItemInterface> flatItems = flattenItems(menu.getItems());
+         assertEquals("Custom", flatItems.get(flatItems.size() - 2).getLabel());
+         assertEquals("Audit", flatItems.get(flatItems.size() - 1).getLabel());
+      }
+
+      /////////////////////////////////////////////////
+      // and before and after the footer list itself //
+      /////////////////////////////////////////////////
+      {
+         QMenuDefaultViewScreenActionsMenu menu = new QMenuDefaultViewScreenActionsMenu();
+         QMenuAdjuster.addAfter(menu, new CustomMenuItem(), new QMenuItemMatcher(QMenuDefaultViewScreenActionsMenu.FooterSubList.class));
+         assertEquals(QMenuDefaultViewScreenActionsMenu.FooterSubList.class, menu.getItems().get(menu.getItems().size() - 2).getClass());
+         assertEquals("Custom", menu.getItems().get(menu.getItems().size() - 1).getLabel());
+      }
+      {
+         QMenuDefaultViewScreenActionsMenu menu = new QMenuDefaultViewScreenActionsMenu();
+         QMenuAdjuster.addBefore(menu, new CustomMenuItem(), new QMenuItemMatcher(QMenuDefaultViewScreenActionsMenu.FooterSubList.class));
+         assertEquals("Custom", menu.getItems().get(menu.getItems().size() - 2).getLabel());
+         assertEquals(QMenuDefaultViewScreenActionsMenu.FooterSubList.class, menu.getItems().get(menu.getItems().size() - 1).getClass());
+      }
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testReplaceItems()
+   {
+      QMenuDefaultViewScreenActionsMenu menu = new QMenuDefaultViewScreenActionsMenu();
+
+      assertTrue(doesMenuHaveItemWithLabel(menu.getItems(), "New"));
+      assertFalse(doesMenuHaveItemWithLabel(menu.getItems(), "Create"));
+      QMenuAdjuster.replaceItem(menu,
+         new QMenuItemBuiltIn(QMenuItemBuiltIn.DefaultOptions.NEW).withLabel("Create"),
+         new QMenuItemMatcher(QMenuItemBuiltIn.DefaultOptions.NEW));
+      assertFalse(doesMenuHaveItemWithLabel(menu.getItems(), "New"));
+      assertTrue(doesMenuHaveItemWithLabel(menu.getItems(), "Create"));
+
+   }
+
+
+
+   /***************************************************************************
+    *
+    ***************************************************************************/
+   private List<QMenuItemInterface> flattenItems(List<QMenuItemInterface> input)
+   {
+      List<QMenuItemInterface> rs = new ArrayList<>();
+      for(QMenuItemInterface item : input)
+      {
+         rs.add(item);
+
+         if(item instanceof QMenuItemSubList subList)
+         {
+            rs.addAll(flattenItems(subList.getItems()));
+         }
+
+         if(item instanceof QMenuItemSubMenu subMenu)
+         {
+            rs.addAll(flattenItems(subMenu.getItems()));
+         }
+      }
+      return (rs);
+   }
+
+
+
+   /***************************************************************************
+    *
+    ***************************************************************************/
+   private boolean doesMenuMatchPredicate(List<QMenuItemInterface> items, Predicate<QMenuItemInterface> predicate)
+   {
+      for(QMenuItemInterface item : CollectionUtils.nonNullList(items))
+      {
+         if(predicate.test(item))
+         {
+            return (true);
+         }
+
+         if(item instanceof QMenuItemSubList subList && doesMenuMatchPredicate(subList.getItems(), predicate))
+         {
+            return (true);
+         }
+
+         if(item instanceof QMenuItemSubMenu subMenu && doesMenuMatchPredicate(subMenu.getItems(), predicate))
+         {
+            return (true);
+         }
+      }
+
+      return (false);
+   }
+
+
+
+   /***************************************************************************
+    *
+    ***************************************************************************/
+   private boolean doesMenuHaveBuiltInOption(List<QMenuItemInterface> items, QMenuItemBuiltIn.BuiltInOptionInterface option)
+   {
+      return (doesMenuMatchPredicate(items, item -> item instanceof QMenuItemBuiltIn b && b.getOption().equals(option)));
+   }
+
+
+
+   /***************************************************************************
+    *
+    ***************************************************************************/
+   private boolean doesMenuHaveItemOfType(List<QMenuItemInterface> items, Class<? extends QMenuItemInterface> itemType)
+   {
+      return (doesMenuMatchPredicate(items, item -> itemType.isAssignableFrom(item.getClass())));
+   }
+
+
+
+   /***************************************************************************
+    *
+    ***************************************************************************/
+   private boolean doesMenuHaveItemWithLabel(List<QMenuItemInterface> items, String label)
+   {
+      return (doesMenuMatchPredicate(items, item -> Objects.equals(item.getLabel(), label)));
+   }
+
+
+
+   /***************************************************************************
+    *
+    ***************************************************************************/
+   private enum CustomBuiltInOptions implements QMenuItemBuiltIn.BuiltInOptionInterface
+   {
+      RED
+   }
+
+
+
+   /***************************************************************************
+    *
+    ***************************************************************************/
+   private static class CustomMenuItem extends QMenuItemBase
+   {
+      /*******************************************************************************
+       ** Constructor
+       **
+       *******************************************************************************/
+      public CustomMenuItem()
+      {
+         setLabel("Custom");
+      }
+
+
+
+      /***************************************************************************
+       *
+       ***************************************************************************/
+      @Override
+      public String getItemType()
+      {
+         return "CUSTOM";
+      }
+   }
+
+}

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemDownloadFileTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/metadata/menus/items/QMenuItemDownloadFileTest.java
@@ -1,0 +1,60 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.menus.items;
+
+
+import com.kingsrook.qqq.backend.core.BaseTest;
+import com.kingsrook.qqq.backend.core.model.metadata.layout.QIcon;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+
+/*******************************************************************************
+ ** Unit test for QMenuItemDownloadFile 
+ *******************************************************************************/
+class QMenuItemDownloadFileTest extends BaseTest
+{
+
+   /*******************************************************************************
+    * basic test of cloning, because, cloning...
+    *******************************************************************************/
+   @Test
+   void testClone()
+   {
+      QMenuItemDownloadFile menuItemDownloadFile = (QMenuItemDownloadFile) new QMenuItemDownloadFile()
+         .withFieldName("myFile")
+         .withLabel("My File")
+         .withIcon(new QIcon().withName("download"));
+
+      QMenuItemDownloadFile clone = menuItemDownloadFile.clone();
+
+      assertEquals(menuItemDownloadFile.getFieldName(), clone.getFieldName());
+
+      clone.setFieldName("yourField");
+      assertNotEquals(menuItemDownloadFile.getFieldName(), clone.getFieldName());
+
+      clone.getIcon().setName("upload");
+      assertNotEquals(menuItemDownloadFile.getIcon().getName(), clone.getIcon().getName());
+   }
+
+}


### PR DESCRIPTION
## Description

Introduces new `QMenu` metadata objects that can be attached to `QTableMetaData`, enabling customizable table-level menu configurations.

## Changes

**Menu System:**
- Created new `QMenu` metadata objects for defining custom menus in table contexts
- Added support for attaching menus to `QTableMetaData` for per-table customization
- Enabled customization of Actions menu contents on record view and query screens
- Supported definition of additional/custom menus for specialized actions

**Use Cases:**
- High-priority process menus
- File download actions from field data
- Custom table-specific action groupings
- Extensible menu framework for future enhancements

## Testing

All existing tests pass. The menu system is designed to be backward compatible with existing table configurations.