### PR TITLE
feat(audits): optional read/view auditing (#388)

### DIFF
--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/audits/ReadAuditAction.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/audits/ReadAuditAction.java
@@ -1,0 +1,302 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2025.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.actions.audits;
+
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import com.kingsrook.qqq.backend.core.context.CapturedContext;
+import com.kingsrook.qqq.backend.core.context.QContext;
+import com.kingsrook.qqq.backend.core.logging.QLogger;
+import com.kingsrook.qqq.backend.core.model.actions.AbstractTableActionInput;
+import com.kingsrook.qqq.backend.core.model.actions.audits.AuditInput;
+import com.kingsrook.qqq.backend.core.model.actions.audits.ReadAuditHandlerInput;
+import com.kingsrook.qqq.backend.core.model.actions.audits.ReadAuditInput;
+import com.kingsrook.qqq.backend.core.model.actions.tables.QInputSource;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.QQueryFilter;
+import com.kingsrook.qqq.backend.core.model.data.QRecord;
+import com.kingsrook.qqq.backend.core.model.metadata.audits.ReadAuditLevel;
+import com.kingsrook.qqq.backend.core.model.metadata.tables.QTableMetaData;
+import com.kingsrook.qqq.backend.core.utils.CollectionUtils;
+import com.kingsrook.qqq.backend.core.utils.QQueryFilterFormatter;
+import static com.kingsrook.qqq.backend.core.actions.audits.AuditAction.getRecordSecurityKeyValues;
+import static com.kingsrook.qqq.backend.core.logging.LogUtils.logPair;
+
+
+/*******************************************************************************
+ ** Audit action for read (view) operations. Fires asynchronously so that read
+ ** performance is not impacted by audit I/O.
+ *******************************************************************************/
+public class ReadAuditAction
+{
+   private static final QLogger LOG = QLogger.getLogger(ReadAuditAction.class);
+
+   private static final String GET_AUDIT_MESSAGE   = "Record was Viewed";
+   private static final String QUERY_AUDIT_MESSAGE = "Record was included in Query result";
+
+   /////////////////////////////////////////////////////////////////////////////////////
+   // thread-local flag to suppress duplicate read audits when GetAction delegates to //
+   // QueryAction via DefaultGetInterface. GetAction sets this before the inner query //
+   // and clears it after, so QueryAction's read audit call is suppressed.            //
+   /////////////////////////////////////////////////////////////////////////////////////
+   private static final ThreadLocal<Boolean> suppressReadAuditThreadLocal = new ThreadLocal<>();
+
+
+
+   /*******************************************************************************
+    ** Suppress read audit on the current thread. Used by GetAction to prevent
+    ** its inner DefaultGetInterface query from firing a duplicate read audit.
+    *******************************************************************************/
+   public static void suppressOnCurrentThread()
+   {
+      suppressReadAuditThreadLocal.set(Boolean.TRUE);
+   }
+
+
+
+   /*******************************************************************************
+    ** Clear the suppression flag on the current thread.
+    *******************************************************************************/
+   public static void unsuppressOnCurrentThread()
+   {
+      suppressReadAuditThreadLocal.remove();
+   }
+
+
+
+   /*******************************************************************************
+    ** Fire-and-forget async read audit. Checks table's readAuditLevel and
+    ** InputSource before submitting to the thread pool. Extracts only primary
+    ** keys and security key values from records on the calling thread to minimize
+    ** memory held by the async closure.
+    **
+    ** @param table the table that was read
+    ** @param actionInput the original get/query input (for InputSource check)
+    ** @param records the records that were returned by the read
+    ** @param readType GET or QUERY
+    ** @param queryFilter the query filter used (null for GET operations)
+    *******************************************************************************/
+   public static void executeAsync(QTableMetaData table, AbstractTableActionInput actionInput, List<QRecord> records, ReadAuditInput.ReadType readType, QQueryFilter queryFilter)
+   {
+      try
+      {
+         if(CollectionUtils.nullSafeIsEmpty(records))
+         {
+            return;
+         }
+
+         ////////////////////////////////////
+         // check thread-local suppression //
+         ////////////////////////////////////
+         if(Boolean.TRUE.equals(suppressReadAuditThreadLocal.get()))
+         {
+            return;
+         }
+
+         ////////////////////////////////////////////////////////
+         // only audit user-facing reads, not system internals //
+         ////////////////////////////////////////////////////////
+         if(!isUserSourced(actionInput))
+         {
+            return;
+         }
+
+         ReadAuditLevel readAuditLevel = getReadAuditLevel(table);
+         if(readAuditLevel == ReadAuditLevel.NONE)
+         {
+            return;
+         }
+
+         if(readAuditLevel == ReadAuditLevel.GET && readType == ReadAuditInput.ReadType.QUERY)
+         {
+            return;
+         }
+
+         /////////////////////////////////////////////////////////////////////////////////
+         // extract only primary keys and security key values from records on the        //
+         // calling thread, so the async closure does not hold full QRecord references. //
+         /////////////////////////////////////////////////////////////////////////////////
+         String primaryKeyField = table.getPrimaryKeyField();
+         List<Serializable> primaryKeys = new ArrayList<>(records.size());
+         List<Map<String, Serializable>> securityKeyValuesList = new ArrayList<>(records.size());
+
+         for(QRecord record : records)
+         {
+            primaryKeys.add(record.getValue(primaryKeyField));
+            securityKeyValuesList.add(getRecordSecurityKeyValues(table, record, Optional.empty()));
+         }
+
+         CapturedContext capturedContext = QContext.capture();
+
+         AuditHandlerExecutor.getExecutorService().submit(() ->
+         {
+            try
+            {
+               QContext.init(capturedContext);
+               executeInBackground(table, primaryKeys, securityKeyValuesList, readType, queryFilter);
+            }
+            catch(Exception e)
+            {
+               LOG.warn("Error performing async read audit", e, logPair("table", table.getName()), logPair("readType", readType));
+            }
+            finally
+            {
+               QContext.clear();
+            }
+         });
+      }
+      catch(Exception e)
+      {
+         LOG.warn("Error submitting read audit", e, logPair("table", table.getName()));
+      }
+   }
+
+
+
+   /*******************************************************************************
+    ** Background execution - builds audit records and inserts them in bulk.
+    **
+    ** @param table the table metadata
+    ** @param primaryKeys the primary key values extracted from the read records
+    ** @param securityKeyValuesList the security key values for each record
+    ** @param readType GET or QUERY
+    ** @param queryFilter the query filter used (null for GET operations)
+    *******************************************************************************/
+   static void executeInBackground(QTableMetaData table, List<Serializable> primaryKeys, List<Map<String, Serializable>> securityKeyValuesList, ReadAuditInput.ReadType readType, QQueryFilter queryFilter)
+   {
+      try
+      {
+         String message = readType == ReadAuditInput.ReadType.QUERY ? QUERY_AUDIT_MESSAGE : GET_AUDIT_MESSAGE;
+
+         /////////////////////////////////////////////////////////////////////////////////
+         // for QUERY operations with a filter, format the filter once and include it   //
+         // as an auditDetail record on each audit entry. Fresh QRecord instances are   //
+         // required per entry because AuditAction.execute() mutates detail records.    //
+         /////////////////////////////////////////////////////////////////////////////////
+         String filterSummary = null;
+         if(readType == ReadAuditInput.ReadType.QUERY && queryFilter != null)
+         {
+            filterSummary = QQueryFilterFormatter.formatQueryFilter(table.getName(), queryFilter);
+         }
+
+         AuditInput auditInput = new AuditInput();
+
+         for(int i = 0; i < primaryKeys.size(); i++)
+         {
+            if(filterSummary != null)
+            {
+               List<QRecord> details = List.of(new QRecord().withValue("message", "Query Filter: " + filterSummary));
+               AuditAction.appendToInput(auditInput, table.getName(), primaryKeys.get(i), securityKeyValuesList.get(i), message, details);
+            }
+            else
+            {
+               AuditAction.appendToInput(auditInput, table.getName(), primaryKeys.get(i), securityKeyValuesList.get(i), message);
+            }
+         }
+
+         new AuditAction().execute(auditInput);
+
+         ///////////////////////////
+         // execute read handlers //
+         ///////////////////////////
+         executeReadHandlers(table, primaryKeys, readType, queryFilter);
+
+         LOG.trace("Read audit completed", logPair("table", table.getName()), logPair("readType", readType), logPair("recordCount", primaryKeys.size()));
+      }
+      catch(Exception e)
+      {
+         LOG.warn("Error performing read audit", e, logPair("table", table.getName()));
+      }
+   }
+
+
+
+   /*******************************************************************************
+    ** Execute read audit handlers for the table.
+    *******************************************************************************/
+   private static void executeReadHandlers(QTableMetaData table, List<Serializable> primaryKeys, ReadAuditInput.ReadType readType, QQueryFilter queryFilter)
+   {
+      try
+      {
+         //////////////////////////////////////////////////////////////////////////////////////
+         // build lightweight QRecords with only the primary key set for handler consumption //
+         //////////////////////////////////////////////////////////////////////////////////////
+         String primaryKeyField = table.getPrimaryKeyField();
+         List<QRecord> records = new ArrayList<>(primaryKeys.size());
+         for(Serializable primaryKey : primaryKeys)
+         {
+            records.add(new QRecord().withValue(primaryKeyField, primaryKey));
+         }
+
+         ReadAuditHandlerInput handlerInput = new ReadAuditHandlerInput()
+            .withTableName(table.getName())
+            .withReadType(readType)
+            .withRecords(records)
+            .withResultCount(primaryKeys.size())
+            .withQueryFilter(queryFilter)
+            .withTimestamp(Instant.now())
+            .withSession(QContext.getQSession());
+
+         new AuditHandlerExecutor().executeReadHandlers(table.getName(), handlerInput);
+      }
+      catch(Exception e)
+      {
+         LOG.warn("Error executing read audit handlers", e, logPair("table", table.getName()));
+      }
+   }
+
+
+
+   /*******************************************************************************
+    ** Get the read audit level for a table, defaulting to NONE.
+    *******************************************************************************/
+   static ReadAuditLevel getReadAuditLevel(QTableMetaData table)
+   {
+      if(table.getAuditRules() == null)
+      {
+         return (ReadAuditLevel.NONE);
+      }
+
+      ReadAuditLevel readAuditLevel = table.getAuditRules().getReadAuditLevel();
+      return (readAuditLevel == null ? ReadAuditLevel.NONE : readAuditLevel);
+   }
+
+
+
+   /*******************************************************************************
+    ** Check if the action's InputSource is USER (not system/internal).
+    *******************************************************************************/
+   private static boolean isUserSourced(AbstractTableActionInput actionInput)
+   {
+      if(actionInput == null || actionInput.getInputSource() == null)
+      {
+         return (false);
+      }
+
+      return (actionInput.getInputSource().equals(QInputSource.USER));
+   }
+
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/audits/ReadAuditHandlerInterface.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/audits/ReadAuditHandlerInterface.java
@@ -19,29 +19,26 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.kingsrook.qqq.backend.core.model.metadata.audits;
+package com.kingsrook.qqq.backend.core.actions.audits;
+
+
+import com.kingsrook.qqq.backend.core.exceptions.QException;
+import com.kingsrook.qqq.backend.core.model.actions.audits.ReadAuditHandlerInput;
 
 
 /*******************************************************************************
- ** Type of audit handler - determines which hook point it receives events from.
+ ** Handler interface for receiving read audit events (views and queries).
+ ** Called from ReadAuditAction after read operations complete.
  *******************************************************************************/
-public enum AuditHandlerType
+public interface ReadAuditHandlerInterface extends AuditHandlerInterface
 {
-   /***************************************************************************
-    ** Handler receives raw DML events with full record snapshots.
-    ** Called from DMLAuditAction with old and new QRecords.
-    ***************************************************************************/
-   DML,
 
    /***************************************************************************
-    ** Handler receives processed audit events (AuditSingleInput).
-    ** Called from AuditAction after audit records are built.
+    ** Handle a read audit event.
+    **
+    ** @param input contains the table, read type, records, and result count
+    ** @throws QException if processing fails
     ***************************************************************************/
-   PROCESSED,
+   void handleReadAudit(ReadAuditHandlerInput input) throws QException;
 
-   /***************************************************************************
-    ** Handler receives read audit events (view/query).
-    ** Called from ReadAuditAction after read operations complete.
-    ***************************************************************************/
-   READ
 }

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/tables/QueryAction.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/tables/QueryAction.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import com.kingsrook.qqq.backend.core.actions.ActionHelper;
+import com.kingsrook.qqq.backend.core.actions.audits.ReadAuditAction;
 import com.kingsrook.qqq.backend.core.actions.customizers.QCodeLoader;
 import com.kingsrook.qqq.backend.core.actions.customizers.TableCustomizerInterface;
 import com.kingsrook.qqq.backend.core.actions.customizers.TableCustomizers;
@@ -49,6 +50,7 @@ import com.kingsrook.qqq.backend.core.actions.values.ValueBehaviorApplier;
 import com.kingsrook.qqq.backend.core.context.QContext;
 import com.kingsrook.qqq.backend.core.exceptions.QException;
 import com.kingsrook.qqq.backend.core.logging.QLogger;
+import com.kingsrook.qqq.backend.core.model.actions.audits.ReadAuditInput;
 import com.kingsrook.qqq.backend.core.model.actions.tables.query.QCriteriaOperator;
 import com.kingsrook.qqq.backend.core.model.actions.tables.query.QFilterCriteria;
 import com.kingsrook.qqq.backend.core.model.actions.tables.query.QQueryFilter;
@@ -165,6 +167,11 @@ public class QueryAction
       if(queryInput.getRecordPipe() == null)
       {
          postRecordActions(queryOutput.getRecords());
+      }
+
+      if(queryInput.getRecordPipe() == null)
+      {
+         ReadAuditAction.executeAsync(table, queryInput, queryOutput.getRecords(), ReadAuditInput.ReadType.QUERY, queryInput.getFilter());
       }
 
       return queryOutput;

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/audits/ReadAuditHandlerInput.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/audits/ReadAuditHandlerInput.java
@@ -1,0 +1,263 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2025.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.actions.audits;
+
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.List;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.QQueryFilter;
+import com.kingsrook.qqq.backend.core.model.data.QRecord;
+import com.kingsrook.qqq.backend.core.model.session.QSession;
+
+
+/*******************************************************************************
+ ** Input for read audit handlers, providing context about viewed records.
+ *******************************************************************************/
+public class ReadAuditHandlerInput implements Serializable
+{
+   private String        tableName;
+   private ReadAuditInput.ReadType readType;
+   private List<QRecord> records;
+   private Integer       resultCount;
+   private QQueryFilter  queryFilter;
+   private Instant       timestamp;
+   private QSession      session;
+
+
+
+   /*******************************************************************************
+    ** Getter for tableName
+    *******************************************************************************/
+   public String getTableName()
+   {
+      return (this.tableName);
+   }
+
+
+
+   /*******************************************************************************
+    ** Setter for tableName
+    *******************************************************************************/
+   public void setTableName(String tableName)
+   {
+      this.tableName = tableName;
+   }
+
+
+
+   /*******************************************************************************
+    ** Fluent setter for tableName
+    *******************************************************************************/
+   public ReadAuditHandlerInput withTableName(String tableName)
+   {
+      this.tableName = tableName;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    ** Getter for readType
+    *******************************************************************************/
+   public ReadAuditInput.ReadType getReadType()
+   {
+      return (this.readType);
+   }
+
+
+
+   /*******************************************************************************
+    ** Setter for readType
+    *******************************************************************************/
+   public void setReadType(ReadAuditInput.ReadType readType)
+   {
+      this.readType = readType;
+   }
+
+
+
+   /*******************************************************************************
+    ** Fluent setter for readType
+    *******************************************************************************/
+   public ReadAuditHandlerInput withReadType(ReadAuditInput.ReadType readType)
+   {
+      this.readType = readType;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    ** Getter for records
+    *******************************************************************************/
+   public List<QRecord> getRecords()
+   {
+      return (this.records);
+   }
+
+
+
+   /*******************************************************************************
+    ** Setter for records
+    *******************************************************************************/
+   public void setRecords(List<QRecord> records)
+   {
+      this.records = records;
+   }
+
+
+
+   /*******************************************************************************
+    ** Fluent setter for records
+    *******************************************************************************/
+   public ReadAuditHandlerInput withRecords(List<QRecord> records)
+   {
+      this.records = records;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    ** Getter for resultCount
+    *******************************************************************************/
+   public Integer getResultCount()
+   {
+      return (this.resultCount);
+   }
+
+
+
+   /*******************************************************************************
+    ** Setter for resultCount
+    *******************************************************************************/
+   public void setResultCount(Integer resultCount)
+   {
+      this.resultCount = resultCount;
+   }
+
+
+
+   /*******************************************************************************
+    ** Fluent setter for resultCount
+    *******************************************************************************/
+   public ReadAuditHandlerInput withResultCount(Integer resultCount)
+   {
+      this.resultCount = resultCount;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    ** Getter for queryFilter
+    *******************************************************************************/
+   public QQueryFilter getQueryFilter()
+   {
+      return (this.queryFilter);
+   }
+
+
+
+   /*******************************************************************************
+    ** Setter for queryFilter
+    *******************************************************************************/
+   public void setQueryFilter(QQueryFilter queryFilter)
+   {
+      this.queryFilter = queryFilter;
+   }
+
+
+
+   /*******************************************************************************
+    ** Fluent setter for queryFilter
+    *******************************************************************************/
+   public ReadAuditHandlerInput withQueryFilter(QQueryFilter queryFilter)
+   {
+      this.queryFilter = queryFilter;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    ** Getter for timestamp
+    *******************************************************************************/
+   public Instant getTimestamp()
+   {
+      return (this.timestamp);
+   }
+
+
+
+   /*******************************************************************************
+    ** Setter for timestamp
+    *******************************************************************************/
+   public void setTimestamp(Instant timestamp)
+   {
+      this.timestamp = timestamp;
+   }
+
+
+
+   /*******************************************************************************
+    ** Fluent setter for timestamp
+    *******************************************************************************/
+   public ReadAuditHandlerInput withTimestamp(Instant timestamp)
+   {
+      this.timestamp = timestamp;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    ** Getter for session
+    *******************************************************************************/
+   public QSession getSession()
+   {
+      return (this.session);
+   }
+
+
+
+   /*******************************************************************************
+    ** Setter for session
+    *******************************************************************************/
+   public void setSession(QSession session)
+   {
+      this.session = session;
+   }
+
+
+
+   /*******************************************************************************
+    ** Fluent setter for session
+    *******************************************************************************/
+   public ReadAuditHandlerInput withSession(QSession session)
+   {
+      this.session = session;
+      return (this);
+   }
+
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/audits/ReadAuditInput.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/audits/ReadAuditInput.java
@@ -1,0 +1,208 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2025.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.actions.audits;
+
+
+import java.io.Serializable;
+import java.util.List;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.QQueryFilter;
+import com.kingsrook.qqq.backend.core.model.data.QRecord;
+
+
+/*******************************************************************************
+ ** Input for the ReadAuditAction, describing which records were read and how.
+ *******************************************************************************/
+public class ReadAuditInput implements Serializable
+{
+   private String        tableName;
+   private ReadType      readType;
+   private List<QRecord> records;
+   private Integer       resultCount;
+   private QQueryFilter  queryFilter;
+
+
+
+   /*******************************************************************************
+    ** Type of read operation being audited.
+    *******************************************************************************/
+   public enum ReadType
+   {
+      GET,
+      QUERY
+   }
+
+
+
+   /*******************************************************************************
+    ** Getter for tableName
+    *******************************************************************************/
+   public String getTableName()
+   {
+      return (this.tableName);
+   }
+
+
+
+   /*******************************************************************************
+    ** Setter for tableName
+    *******************************************************************************/
+   public void setTableName(String tableName)
+   {
+      this.tableName = tableName;
+   }
+
+
+
+   /*******************************************************************************
+    ** Fluent setter for tableName
+    *******************************************************************************/
+   public ReadAuditInput withTableName(String tableName)
+   {
+      this.tableName = tableName;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    ** Getter for readType
+    *******************************************************************************/
+   public ReadType getReadType()
+   {
+      return (this.readType);
+   }
+
+
+
+   /*******************************************************************************
+    ** Setter for readType
+    *******************************************************************************/
+   public void setReadType(ReadType readType)
+   {
+      this.readType = readType;
+   }
+
+
+
+   /*******************************************************************************
+    ** Fluent setter for readType
+    *******************************************************************************/
+   public ReadAuditInput withReadType(ReadType readType)
+   {
+      this.readType = readType;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    ** Getter for records
+    *******************************************************************************/
+   public List<QRecord> getRecords()
+   {
+      return (this.records);
+   }
+
+
+
+   /*******************************************************************************
+    ** Setter for records
+    *******************************************************************************/
+   public void setRecords(List<QRecord> records)
+   {
+      this.records = records;
+   }
+
+
+
+   /*******************************************************************************
+    ** Fluent setter for records
+    *******************************************************************************/
+   public ReadAuditInput withRecords(List<QRecord> records)
+   {
+      this.records = records;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    ** Getter for resultCount
+    *******************************************************************************/
+   public Integer getResultCount()
+   {
+      return (this.resultCount);
+   }
+
+
+
+   /*******************************************************************************
+    ** Setter for resultCount
+    *******************************************************************************/
+   public void setResultCount(Integer resultCount)
+   {
+      this.resultCount = resultCount;
+   }
+
+
+
+   /*******************************************************************************
+    ** Fluent setter for resultCount
+    *******************************************************************************/
+   public ReadAuditInput withResultCount(Integer resultCount)
+   {
+      this.resultCount = resultCount;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    ** Getter for queryFilter
+    *******************************************************************************/
+   public QQueryFilter getQueryFilter()
+   {
+      return (this.queryFilter);
+   }
+
+
+
+   /*******************************************************************************
+    ** Setter for queryFilter
+    *******************************************************************************/
+   public void setQueryFilter(QQueryFilter queryFilter)
+   {
+      this.queryFilter = queryFilter;
+   }
+
+
+
+   /*******************************************************************************
+    ** Fluent setter for queryFilter
+    *******************************************************************************/
+   public ReadAuditInput withQueryFilter(QQueryFilter queryFilter)
+   {
+      this.queryFilter = queryFilter;
+      return (this);
+   }
+
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/audits/QAuditRules.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/audits/QAuditRules.java
@@ -30,7 +30,8 @@ import com.kingsrook.qqq.backend.core.model.metadata.QMetaDataObject;
  *******************************************************************************/
 public class QAuditRules implements QMetaDataObject, Cloneable
 {
-   private AuditLevel auditLevel;
+   private AuditLevel     auditLevel;
+   private ReadAuditLevel readAuditLevel;
 
 
 
@@ -71,6 +72,37 @@ public class QAuditRules implements QMetaDataObject, Cloneable
    public QAuditRules withAuditLevel(AuditLevel auditLevel)
    {
       this.auditLevel = auditLevel;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    ** Getter for readAuditLevel
+    *******************************************************************************/
+   public ReadAuditLevel getReadAuditLevel()
+   {
+      return (this.readAuditLevel);
+   }
+
+
+
+   /*******************************************************************************
+    ** Setter for readAuditLevel
+    *******************************************************************************/
+   public void setReadAuditLevel(ReadAuditLevel readAuditLevel)
+   {
+      this.readAuditLevel = readAuditLevel;
+   }
+
+
+
+   /*******************************************************************************
+    ** Fluent setter for readAuditLevel
+    *******************************************************************************/
+   public QAuditRules withReadAuditLevel(ReadAuditLevel readAuditLevel)
+   {
+      this.readAuditLevel = readAuditLevel;
       return (this);
    }
 

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/audits/ReadAuditLevel.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/audits/ReadAuditLevel.java
@@ -23,25 +23,11 @@ package com.kingsrook.qqq.backend.core.model.metadata.audits;
 
 
 /*******************************************************************************
- ** Type of audit handler - determines which hook point it receives events from.
+ ** Level of read (view) auditing to perform on a table.
  *******************************************************************************/
-public enum AuditHandlerType
+public enum ReadAuditLevel
 {
-   /***************************************************************************
-    ** Handler receives raw DML events with full record snapshots.
-    ** Called from DMLAuditAction with old and new QRecords.
-    ***************************************************************************/
-   DML,
-
-   /***************************************************************************
-    ** Handler receives processed audit events (AuditSingleInput).
-    ** Called from AuditAction after audit records are built.
-    ***************************************************************************/
-   PROCESSED,
-
-   /***************************************************************************
-    ** Handler receives read audit events (view/query).
-    ** Called from ReadAuditAction after read operations complete.
-    ***************************************************************************/
-   READ
+   NONE,
+   GET,
+   GET_AND_QUERY
 }

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/actions/audits/ReadAuditActionTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/actions/audits/ReadAuditActionTest.java
@@ -1,0 +1,621 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2025.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.actions.audits;
+
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import com.kingsrook.qqq.backend.core.BaseTest;
+import com.kingsrook.qqq.backend.core.actions.tables.GetAction;
+import com.kingsrook.qqq.backend.core.actions.tables.InsertAction;
+import com.kingsrook.qqq.backend.core.actions.tables.QueryAction;
+import com.kingsrook.qqq.backend.core.context.QContext;
+import com.kingsrook.qqq.backend.core.exceptions.QException;
+import com.kingsrook.qqq.backend.core.model.actions.audits.ReadAuditHandlerInput;
+import com.kingsrook.qqq.backend.core.model.actions.audits.ReadAuditInput;
+import com.kingsrook.qqq.backend.core.model.actions.tables.QInputSource;
+import com.kingsrook.qqq.backend.core.model.actions.tables.get.GetInput;
+import com.kingsrook.qqq.backend.core.model.actions.tables.get.GetOutput;
+import com.kingsrook.qqq.backend.core.model.actions.tables.insert.InsertInput;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.QCriteriaOperator;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.QFilterCriteria;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.QQueryFilter;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.QueryInput;
+import com.kingsrook.qqq.backend.core.model.audits.AuditsMetaDataProvider;
+import com.kingsrook.qqq.backend.core.model.data.QRecord;
+import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
+import com.kingsrook.qqq.backend.core.model.metadata.audits.AuditHandlerType;
+import com.kingsrook.qqq.backend.core.model.metadata.audits.QAuditHandlerMetaData;
+import com.kingsrook.qqq.backend.core.model.metadata.audits.QAuditRules;
+import com.kingsrook.qqq.backend.core.model.metadata.audits.ReadAuditLevel;
+import com.kingsrook.qqq.backend.core.model.metadata.code.QCodeReference;
+import com.kingsrook.qqq.backend.core.model.metadata.tables.QTableMetaData;
+import com.kingsrook.qqq.backend.core.utils.TestUtils;
+import org.junit.jupiter.api.Test;
+import static com.kingsrook.qqq.backend.core.actions.audits.AuditAction.getRecordSecurityKeyValues;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/*******************************************************************************
+ ** Unit test for ReadAuditAction.
+ *******************************************************************************/
+class ReadAuditActionTest extends BaseTest
+{
+   private static final Integer ASYNC_WAIT_MS = 500;
+
+
+
+   /*******************************************************************************
+    ** Helper to set up audit infrastructure and insert test data.
+    *******************************************************************************/
+   private void setupAuditInfrastructure(ReadAuditLevel readAuditLevel) throws QException
+   {
+      QInstance qInstance = QContext.getQInstance();
+      new AuditsMetaDataProvider().defineAll(qInstance, TestUtils.MEMORY_BACKEND_NAME, null);
+
+      QTableMetaData table = qInstance.getTable(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      if(table.getAuditRules() == null)
+      {
+         table.setAuditRules(new QAuditRules());
+      }
+      table.getAuditRules().setReadAuditLevel(readAuditLevel);
+
+      ///////////////////////////
+      // insert some test data //
+      ///////////////////////////
+      InsertInput insertInput = new InsertInput();
+      insertInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      insertInput.setRecords(List.of(
+         new QRecord().withValue("id", 1).withValue("firstName", "Darin").withValue("lastName", "Kelkhoff"),
+         new QRecord().withValue("id", 2).withValue("firstName", "Tim").withValue("lastName", "Chamberlain"),
+         new QRecord().withValue("id", 3).withValue("firstName", "James").withValue("lastName", "Maes")
+      ));
+      new InsertAction().execute(insertInput);
+   }
+
+
+
+   /*******************************************************************************
+    ** Wait for async audit to complete.
+    *******************************************************************************/
+   private void waitForAsyncAudit() throws InterruptedException
+   {
+      Thread.sleep(ASYNC_WAIT_MS);
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that readAuditLevel=NONE produces no audits on GET.
+    *******************************************************************************/
+   @Test
+   void testReadAuditLevelNone_noAuditsOnGet() throws Exception
+   {
+      setupAuditInfrastructure(ReadAuditLevel.NONE);
+
+      GetInput getInput = new GetInput();
+      getInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      getInput.setPrimaryKey(1);
+      getInput.setInputSource(QInputSource.USER);
+      new GetAction().execute(getInput);
+
+      waitForAsyncAudit();
+
+      List<QRecord> audits = TestUtils.queryTable("audit");
+      assertTrue(audits.isEmpty(), "No audits should be created when readAuditLevel is NONE");
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that readAuditLevel=NONE produces no audits on Query.
+    *******************************************************************************/
+   @Test
+   void testReadAuditLevelNone_noAuditsOnQuery() throws Exception
+   {
+      setupAuditInfrastructure(ReadAuditLevel.NONE);
+
+      QueryInput queryInput = new QueryInput();
+      queryInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      queryInput.setInputSource(QInputSource.USER);
+      new QueryAction().execute(queryInput);
+
+      waitForAsyncAudit();
+
+      List<QRecord> audits = TestUtils.queryTable("audit");
+      assertTrue(audits.isEmpty(), "No audits should be created when readAuditLevel is NONE");
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that readAuditLevel=GET produces audit on single-record GET.
+    *******************************************************************************/
+   @Test
+   void testReadAuditLevelGet_auditsOnGet() throws Exception
+   {
+      setupAuditInfrastructure(ReadAuditLevel.GET);
+
+      GetInput getInput = new GetInput();
+      getInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      getInput.setPrimaryKey(1);
+      getInput.setInputSource(QInputSource.USER);
+      new GetAction().execute(getInput);
+
+      waitForAsyncAudit();
+
+      List<QRecord> audits = TestUtils.queryTable("audit");
+      assertEquals(1, audits.size(), "One audit record should be created for GET");
+      assertThat(audits.get(0).getValueString("message")).isEqualTo("Record was Viewed");
+      assertEquals(1, audits.get(0).getValueInteger("recordId"));
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that readAuditLevel=GET does NOT produce audits on Query.
+    *******************************************************************************/
+   @Test
+   void testReadAuditLevelGet_noAuditsOnQuery() throws Exception
+   {
+      setupAuditInfrastructure(ReadAuditLevel.GET);
+
+      QueryInput queryInput = new QueryInput();
+      queryInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      queryInput.setInputSource(QInputSource.USER);
+      new QueryAction().execute(queryInput);
+
+      waitForAsyncAudit();
+
+      List<QRecord> audits = TestUtils.queryTable("audit");
+      assertTrue(audits.isEmpty(), "No audits should be created for Query when readAuditLevel is GET");
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that readAuditLevel=GET_AND_QUERY produces audits on GET.
+    *******************************************************************************/
+   @Test
+   void testReadAuditLevelGetAndQuery_auditsOnGet() throws Exception
+   {
+      setupAuditInfrastructure(ReadAuditLevel.GET_AND_QUERY);
+
+      GetInput getInput = new GetInput();
+      getInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      getInput.setPrimaryKey(1);
+      getInput.setInputSource(QInputSource.USER);
+      new GetAction().execute(getInput);
+
+      waitForAsyncAudit();
+
+      List<QRecord> audits = TestUtils.queryTable("audit");
+      assertEquals(1, audits.size(), "One audit record should be created for GET");
+      assertThat(audits.get(0).getValueString("message")).isEqualTo("Record was Viewed");
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that readAuditLevel=GET_AND_QUERY produces per-record audits on Query.
+    *******************************************************************************/
+   @Test
+   void testReadAuditLevelGetAndQuery_auditsOnQuery() throws Exception
+   {
+      setupAuditInfrastructure(ReadAuditLevel.GET_AND_QUERY);
+
+      QueryInput queryInput = new QueryInput();
+      queryInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      queryInput.setInputSource(QInputSource.USER);
+      new QueryAction().execute(queryInput);
+
+      waitForAsyncAudit();
+
+      List<QRecord> audits = TestUtils.queryTable("audit");
+      assertEquals(3, audits.size(), "One audit record per queried record (3 records)");
+      for(QRecord audit : audits)
+      {
+         assertThat(audit.getValueString("message")).isEqualTo("Record was included in Query result");
+      }
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that SYSTEM input source does not produce read audits.
+    *******************************************************************************/
+   @Test
+   void testSystemInputSource_noAudits() throws Exception
+   {
+      setupAuditInfrastructure(ReadAuditLevel.GET_AND_QUERY);
+
+      /////////////////////////////////////////////////////////////////////
+      // default InputSource is SYSTEM - should NOT produce read audits //
+      /////////////////////////////////////////////////////////////////////
+      GetInput getInput = new GetInput();
+      getInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      getInput.setPrimaryKey(1);
+      new GetAction().execute(getInput);
+
+      waitForAsyncAudit();
+
+      List<QRecord> audits = TestUtils.queryTable("audit");
+      assertTrue(audits.isEmpty(), "System-sourced reads should not produce audits");
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that GET of non-existent record produces no audit.
+    *******************************************************************************/
+   @Test
+   void testGetNonExistentRecord_noAudit() throws Exception
+   {
+      setupAuditInfrastructure(ReadAuditLevel.GET);
+
+      GetInput getInput = new GetInput();
+      getInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      getInput.setPrimaryKey(999);
+      getInput.setInputSource(QInputSource.USER);
+      new GetAction().execute(getInput);
+
+      waitForAsyncAudit();
+
+      List<QRecord> audits = TestUtils.queryTable("audit");
+      assertTrue(audits.isEmpty(), "No audit should be created when record not found");
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that null readAuditLevel (default) behaves like NONE.
+    *******************************************************************************/
+   @Test
+   void testNullReadAuditLevel_behavesAsNone() throws Exception
+   {
+      QInstance qInstance = QContext.getQInstance();
+      new AuditsMetaDataProvider().defineAll(qInstance, TestUtils.MEMORY_BACKEND_NAME, null);
+
+      QTableMetaData table = qInstance.getTable(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      table.setAuditRules(new QAuditRules());
+
+      ///////////////////////////
+      // insert some test data //
+      ///////////////////////////
+      InsertInput insertInput = new InsertInput();
+      insertInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      insertInput.setRecords(List.of(
+         new QRecord().withValue("id", 1).withValue("firstName", "Darin").withValue("lastName", "Kelkhoff")
+      ));
+      new InsertAction().execute(insertInput);
+
+      GetInput getInput = new GetInput();
+      getInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      getInput.setPrimaryKey(1);
+      getInput.setInputSource(QInputSource.USER);
+      new GetAction().execute(getInput);
+
+      waitForAsyncAudit();
+
+      List<QRecord> audits = TestUtils.queryTable("audit");
+      assertTrue(audits.isEmpty(), "Null readAuditLevel should behave as NONE");
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that no audits for tables with null audit rules.
+    *******************************************************************************/
+   @Test
+   void testNullAuditRules_noAudits() throws Exception
+   {
+      QInstance qInstance = QContext.getQInstance();
+      new AuditsMetaDataProvider().defineAll(qInstance, TestUtils.MEMORY_BACKEND_NAME, null);
+
+      QTableMetaData table = qInstance.getTable(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      table.setAuditRules(null);
+
+      InsertInput insertInput = new InsertInput();
+      insertInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      insertInput.setRecords(List.of(
+         new QRecord().withValue("id", 1).withValue("firstName", "Darin").withValue("lastName", "Kelkhoff")
+      ));
+      new InsertAction().execute(insertInput);
+
+      GetInput getInput = new GetInput();
+      getInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      getInput.setPrimaryKey(1);
+      getInput.setInputSource(QInputSource.USER);
+      new GetAction().execute(getInput);
+
+      waitForAsyncAudit();
+
+      List<QRecord> audits = TestUtils.queryTable("audit");
+      assertTrue(audits.isEmpty(), "Null audit rules should produce no audits");
+   }
+
+
+
+   /*******************************************************************************
+    ** Test the executeInBackground method directly (synchronous path for coverage).
+    *******************************************************************************/
+   @Test
+   void testExecuteInBackground_directCall() throws Exception
+   {
+      setupAuditInfrastructure(ReadAuditLevel.GET);
+
+      QTableMetaData table = QContext.getQInstance().getTable(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      QRecord record = new QRecord().withValue("id", 1).withValue("firstName", "Darin").withValue("lastName", "Kelkhoff");
+
+      List<Serializable> primaryKeys = List.of(record.getValue(table.getPrimaryKeyField()));
+      List<Map<String, Serializable>> securityKeyValuesList = List.of(getRecordSecurityKeyValues(table, record, Optional.empty()));
+
+      ReadAuditAction.executeInBackground(table, primaryKeys, securityKeyValuesList, ReadAuditInput.ReadType.GET, null);
+
+      List<QRecord> audits = TestUtils.queryTable("audit");
+      assertEquals(1, audits.size());
+      assertThat(audits.get(0).getValueString("message")).isEqualTo("Record was Viewed");
+   }
+
+
+
+   /*******************************************************************************
+    ** Test the getReadAuditLevel helper method.
+    *******************************************************************************/
+   @Test
+   void testGetReadAuditLevel()
+   {
+      QTableMetaData table = QContext.getQInstance().getTable(TestUtils.TABLE_NAME_PERSON_MEMORY);
+
+      //////////////////////////////////////////////
+      // null audit rules should return NONE      //
+      //////////////////////////////////////////////
+      table.setAuditRules(null);
+      assertEquals(ReadAuditLevel.NONE, ReadAuditAction.getReadAuditLevel(table));
+
+      ///////////////////////////////////////////////////
+      // null readAuditLevel should default to NONE    //
+      ///////////////////////////////////////////////////
+      table.setAuditRules(new QAuditRules());
+      assertEquals(ReadAuditLevel.NONE, ReadAuditAction.getReadAuditLevel(table));
+
+      ///////////////////////////////////////////////////
+      // explicit level should be returned as-is       //
+      ///////////////////////////////////////////////////
+      table.setAuditRules(new QAuditRules().withReadAuditLevel(ReadAuditLevel.GET));
+      assertEquals(ReadAuditLevel.GET, ReadAuditAction.getReadAuditLevel(table));
+
+      table.setAuditRules(new QAuditRules().withReadAuditLevel(ReadAuditLevel.GET_AND_QUERY));
+      assertEquals(ReadAuditLevel.GET_AND_QUERY, ReadAuditAction.getReadAuditLevel(table));
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that GET read audits produce no detail records.
+    *******************************************************************************/
+   @Test
+   void testGetReadAudit_noDetailRecords() throws Exception
+   {
+      setupAuditInfrastructure(ReadAuditLevel.GET_AND_QUERY);
+
+      GetInput getInput = new GetInput();
+      getInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      getInput.setPrimaryKey(1);
+      getInput.setInputSource(QInputSource.USER);
+      new GetAction().execute(getInput);
+
+      waitForAsyncAudit();
+
+      List<QRecord> audits = TestUtils.queryTable("audit");
+      assertEquals(1, audits.size());
+
+      List<QRecord> details = TestUtils.queryTable("auditDetail");
+      assertTrue(details.isEmpty(), "GET read audits should not produce detail records");
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that QUERY read audits include the filter summary as auditDetail records.
+    *******************************************************************************/
+   @Test
+   void testQueryReadAudit_includesFilterSummaryInAuditDetail() throws Exception
+   {
+      setupAuditInfrastructure(ReadAuditLevel.GET_AND_QUERY);
+
+      QueryInput queryInput = new QueryInput();
+      queryInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      queryInput.setInputSource(QInputSource.USER);
+      queryInput.setFilter(new QQueryFilter()
+         .withCriteria(new QFilterCriteria("firstName", QCriteriaOperator.EQUALS, "Darin")));
+      new QueryAction().execute(queryInput);
+
+      waitForAsyncAudit();
+
+      List<QRecord> audits = TestUtils.queryTable("audit");
+      assertEquals(1, audits.size(), "One audit record for the one matching record");
+
+      List<QRecord> details = TestUtils.queryTable("auditDetail");
+      assertEquals(1, details.size(), "One auditDetail record for the query filter summary");
+      assertThat(details.get(0).getValueString("message")).startsWith("Query Filter:");
+      assertThat(details.get(0).getValueString("message")).contains("equals");
+      assertThat(details.get(0).getValueString("message")).contains("Darin");
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that audit failure does not propagate to the read operation.
+    ** The GET should return normally even if the async audit fails.
+    *******************************************************************************/
+   @Test
+   void testAuditFailure_doesNotPropagateToReadOperation() throws Exception
+   {
+      setupAuditInfrastructure(ReadAuditLevel.GET);
+
+      //////////////////////////////////////////////////////////////////////////
+      // remove the audit table after setup to force the async audit to fail //
+      //////////////////////////////////////////////////////////////////////////
+      QContext.getQInstance().getTables().remove(AuditsMetaDataProvider.TABLE_NAME_AUDIT);
+
+      GetInput getInput = new GetInput();
+      getInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      getInput.setPrimaryKey(1);
+      getInput.setInputSource(QInputSource.USER);
+      GetOutput getOutput = new GetAction().execute(getInput);
+
+      ///////////////////////////////////////////////////////////////////////////
+      // the GET should succeed - the record should be returned regardless of //
+      // whether the background audit succeeds or fails                       //
+      ///////////////////////////////////////////////////////////////////////////
+      assertNotNull(getOutput.getRecord(), "GET should return a record even if audit will fail");
+      assertEquals(1, getOutput.getRecord().getValueInteger("id"));
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that a READ audit handler receives events correctly.
+    *******************************************************************************/
+   @Test
+   void testReadHandler_receivesEvents() throws Exception
+   {
+      setupAuditInfrastructure(ReadAuditLevel.GET);
+      CapturingReadAuditHandler.capturedInputs.clear();
+
+      /////////////////////////////////////////
+      // register a READ handler for testing //
+      /////////////////////////////////////////
+      QContext.getQInstance().addAuditHandler(new QAuditHandlerMetaData()
+         .withName("testReadHandler")
+         .withHandlerCode(new QCodeReference(CapturingReadAuditHandler.class))
+         .withHandlerType(AuditHandlerType.READ)
+         .withIsAsync(false)
+         .withEnabled(true));
+
+      GetInput getInput = new GetInput();
+      getInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      getInput.setPrimaryKey(1);
+      getInput.setInputSource(QInputSource.USER);
+      new GetAction().execute(getInput);
+
+      waitForAsyncAudit();
+
+      ////////////////////////////////////////////////
+      // verify the handler was called with correct  //
+      // table, readType, and record count           //
+      ////////////////////////////////////////////////
+      assertEquals(1, CapturingReadAuditHandler.capturedInputs.size());
+      ReadAuditHandlerInput handlerInput = CapturingReadAuditHandler.capturedInputs.get(0);
+      assertEquals(TestUtils.TABLE_NAME_PERSON_MEMORY, handlerInput.getTableName());
+      assertEquals(ReadAuditInput.ReadType.GET, handlerInput.getReadType());
+      assertEquals(1, handlerInput.getResultCount());
+      assertNotNull(handlerInput.getTimestamp());
+      assertNotNull(handlerInput.getSession());
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that reading audit system tables does not produce recursive read audits.
+    ** Audit tables have no readAuditLevel configured, so reading them should not
+    ** trigger further audit writes.
+    *******************************************************************************/
+   @Test
+   void testNoRecursion_readingAuditTables() throws Exception
+   {
+      setupAuditInfrastructure(ReadAuditLevel.GET);
+
+      //////////////////////////////////////////////////////////////////
+      // first, do a GET to produce an audit record in the audit table //
+      //////////////////////////////////////////////////////////////////
+      GetInput getInput = new GetInput();
+      getInput.setTableName(TestUtils.TABLE_NAME_PERSON_MEMORY);
+      getInput.setPrimaryKey(1);
+      getInput.setInputSource(QInputSource.USER);
+      new GetAction().execute(getInput);
+
+      waitForAsyncAudit();
+
+      List<QRecord> audits = TestUtils.queryTable("audit");
+      assertEquals(1, audits.size(), "One audit from the person GET");
+
+      //////////////////////////////////////////////////////////////////////
+      // now query the audit table itself - this should NOT produce       //
+      // additional audit records, since the audit table has no           //
+      // readAuditLevel configured (defaults to NONE).                    //
+      //////////////////////////////////////////////////////////////////////
+      QueryInput auditQuery = new QueryInput();
+      auditQuery.setTableName(AuditsMetaDataProvider.TABLE_NAME_AUDIT);
+      auditQuery.setInputSource(QInputSource.USER);
+      new QueryAction().execute(auditQuery);
+
+      waitForAsyncAudit();
+
+      ////////////////////////////////////////////////////////////////////
+      // verify no additional audits were created from reading the      //
+      // audit table. Only the original 1 audit from the person GET.   //
+      ////////////////////////////////////////////////////////////////////
+      List<QRecord> auditsAfter = TestUtils.queryTable("audit");
+      assertEquals(1, auditsAfter.size(), "No additional audit records should be created from reading the audit table");
+   }
+
+
+
+   /*******************************************************************************
+    ** Test handler for capturing read audit handler invocations.
+    *******************************************************************************/
+   public static class CapturingReadAuditHandler implements ReadAuditHandlerInterface
+   {
+      static List<ReadAuditHandlerInput> capturedInputs = new CopyOnWriteArrayList<>();
+
+
+
+      /*******************************************************************************
+       ** Getter for name
+       *******************************************************************************/
+      @Override
+      public String getName()
+      {
+         return ("capturingReadAuditHandler");
+      }
+
+
+
+      /*******************************************************************************
+       ** Handle read audit by capturing the input.
+       *******************************************************************************/
+      @Override
+      public void handleReadAudit(ReadAuditHandlerInput input) throws QException
+      {
+         capturedInputs.add(input);
+      }
+   }
+
+}

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/instances/QInstanceValidatorTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/instances/QInstanceValidatorTest.java
@@ -60,6 +60,8 @@ import com.kingsrook.qqq.backend.core.model.actions.tables.query.QQueryFilter;
 import com.kingsrook.qqq.backend.core.model.data.QRecord;
 import com.kingsrook.qqq.backend.core.model.metadata.QBackendMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
+import com.kingsrook.qqq.backend.core.model.metadata.audits.QAuditRules;
+import com.kingsrook.qqq.backend.core.model.metadata.audits.ReadAuditLevel;
 import com.kingsrook.qqq.backend.core.model.metadata.authentication.AuthScope;
 import com.kingsrook.qqq.backend.core.model.metadata.authentication.QAuthenticationMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.code.QCodeReference;
@@ -2728,6 +2730,21 @@ public class QInstanceValidatorTest extends BaseTest
    private TableAutomationAction getAction0(QInstance qInstance)
    {
       return qInstance.getTable(TestUtils.TABLE_NAME_PERSON_MEMORY).getAutomationDetails().getActions().get(0);
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that readAuditLevel != NONE fails validation when audit table is
+    ** not defined in the instance.
+    *******************************************************************************/
+   @Test
+   void testReadAuditLevel_failsWithoutAuditTable()
+   {
+      assertValidationFailureReasonsAllowingExtraReasons(
+         (qInstance) -> qInstance.getTable(TestUtils.TABLE_NAME_PERSON_MEMORY)
+            .setAuditRules(new QAuditRules().withReadAuditLevel(ReadAuditLevel.GET)),
+         "readAuditLevel=GET, but the audit table is not defined");
    }
 
 


### PR DESCRIPTION
## Summary
- Adds `ReadAuditLevel` (NONE/GET/GET_AND_QUERY) on `QAuditRules` to optionally audit read operations (views and queries)
- Async fire-and-forget via shared `AuditHandlerExecutor` thread pool -- never blocks or fails reads
- QUERY audits include filter summary as `auditDetail` records; GET audits have no details
- New `READ` handler type with `ReadAuditHandlerInterface` for custom read audit processing
- InputSource guard (USER only) and recursion prevention (audit tables have no readAuditLevel)
- `QInstanceValidator` checks: READ handler code references and audit table existence when readAuditLevel != NONE

## Test plan
- [x] 17 tests in `ReadAuditActionTest` covering all `ReadAuditLevel` combinations, InputSource filtering, async isolation, handler invocation, recursion prevention, and auditDetail filter summaries
- [x] `QInstanceValidatorTest` for readAuditLevel validation
- [x] `GetActionTest` and `QueryActionTest` pass with integration changes

Closes #388