### PR TITLE
Feature/quick views

### DIFF
--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/savedviews/QuickSavedView.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/savedviews/QuickSavedView.java
@@ -53,6 +53,9 @@ public class QuickSavedView extends QRecordEntity
    @QField(isEditable = false)
    private Instant modifyDate;
 
+   @QField(isRequired = true)
+   private String label;
+
    @QField(isRequired = true, possibleValueSourceName = SavedView.TABLE_NAME)
    private Integer savedViewId;
 
@@ -342,6 +345,44 @@ public class QuickSavedView extends QRecordEntity
    public QuickSavedView withUserId(String userId)
    {
       this.userId = userId;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for label
+    * @see #withLabel(String)
+    *******************************************************************************/
+   public String getLabel()
+   {
+      return (this.label);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for label
+    * @see #withLabel(String)
+    *******************************************************************************/
+   public void setLabel(String label)
+   {
+      this.label = label;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for label
+    *
+    * @param label
+    * Label for the quick saved view.  As you might want it different (shorter) than
+    * the saved view, and/or, different users might want it different.
+    * @return this
+    *******************************************************************************/
+   public QuickSavedView withLabel(String label)
+   {
+      this.label = label;
       return (this);
    }
 

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/savedviews/QuickSavedView.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/savedviews/QuickSavedView.java
@@ -30,11 +30,19 @@ import com.kingsrook.qqq.backend.core.model.data.QRecordEntity;
 
 
 /*******************************************************************************
- ** Entity bean for the saved view table
+ * Entity bean for the quick saved view table - a many to one join
+ * with SavedView, for display in as a "quick" view.
+ *
+ * <p>This is a many-to-one join with saved view, because there's some data in
+ * this table that might be adjusted per-user (sortOrder, doCount).  So in addition
+ * to sharing a SavedView to a user (or, in an application via additional fields
+ * like a groupId or userTypeId), a QuickSavedView against one SavedView can be
+ * set up for multiple users (groups, etc in application-layer) with different values
+ * for those settings.</p>
  *******************************************************************************/
-public class SavedView extends QRecordEntity
+public class QuickSavedView extends QRecordEntity
 {
-   public static final String TABLE_NAME = "savedView";
+   public static final String TABLE_NAME = "quickSavedView";
 
    @QField(isEditable = false)
    private Integer id;
@@ -45,17 +53,17 @@ public class SavedView extends QRecordEntity
    @QField(isEditable = false)
    private Instant modifyDate;
 
-   @QField(isRequired = true)
-   private String label;
+   @QField(isRequired = true, possibleValueSourceName = SavedView.TABLE_NAME)
+   private Integer savedViewId;
 
-   @QField(isEditable = false)
-   private String tableName;
-
-   @QField(isEditable = false)
+   @QField(label = "User")
    private String userId;
 
-   @QField(isEditable = false)
-   private String viewJson;
+   @QField(defaultValue = "1")
+   private Integer sortOrder;
+
+   @QField(defaultValue = "false")
+   private Boolean doCount;
 
 
 
@@ -63,7 +71,7 @@ public class SavedView extends QRecordEntity
     ** Constructor
     **
     *******************************************************************************/
-   public SavedView()
+   public QuickSavedView()
    {
    }
 
@@ -73,7 +81,7 @@ public class SavedView extends QRecordEntity
     ** Constructor
     **
     *******************************************************************************/
-   public SavedView(QRecord qRecord) throws QException
+   public QuickSavedView(QRecord qRecord) throws QException
    {
       populateFromQRecord(qRecord);
    }
@@ -81,19 +89,19 @@ public class SavedView extends QRecordEntity
 
 
    /*******************************************************************************
-    ** Getter for id
-    **
+    * Getter for id
+    * @see #withId(Integer)
     *******************************************************************************/
    public Integer getId()
    {
-      return id;
+      return (this.id);
    }
 
 
 
    /*******************************************************************************
-    ** Setter for id
-    **
+    * Setter for id
+    * @see #withId(Integer)
     *******************************************************************************/
    public void setId(Integer id)
    {
@@ -103,19 +111,34 @@ public class SavedView extends QRecordEntity
 
 
    /*******************************************************************************
-    ** Getter for createDate
-    **
+    * Fluent setter for id
+    *
+    * @param id
+    * primary key of the record
+    * @return this
     *******************************************************************************/
-   public Instant getCreateDate()
+   public QuickSavedView withId(Integer id)
    {
-      return createDate;
+      this.id = id;
+      return (this);
    }
 
 
 
    /*******************************************************************************
-    ** Setter for createDate
-    **
+    * Getter for createDate
+    * @see #withCreateDate(Instant)
+    *******************************************************************************/
+   public Instant getCreateDate()
+   {
+      return (this.createDate);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for createDate
+    * @see #withCreateDate(Instant)
     *******************************************************************************/
    public void setCreateDate(Instant createDate)
    {
@@ -125,19 +148,34 @@ public class SavedView extends QRecordEntity
 
 
    /*******************************************************************************
-    ** Getter for modifyDate
-    **
+    * Fluent setter for createDate
+    *
+    * @param createDate
+    * create date of the record
+    * @return this
     *******************************************************************************/
-   public Instant getModifyDate()
+   public QuickSavedView withCreateDate(Instant createDate)
    {
-      return modifyDate;
+      this.createDate = createDate;
+      return (this);
    }
 
 
 
    /*******************************************************************************
-    ** Setter for modifyDate
-    **
+    * Getter for modifyDate
+    * @see #withModifyDate(Instant)
+    *******************************************************************************/
+   public Instant getModifyDate()
+   {
+      return (this.modifyDate);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for modifyDate
+    * @see #withModifyDate(Instant)
     *******************************************************************************/
    public void setModifyDate(Instant modifyDate)
    {
@@ -147,87 +185,145 @@ public class SavedView extends QRecordEntity
 
 
    /*******************************************************************************
-    ** Getter for label
-    **
+    * Fluent setter for modifyDate
+    *
+    * @param modifyDate
+    * modify date of the record
+    * @return this
     *******************************************************************************/
-   public String getLabel()
+   public QuickSavedView withModifyDate(Instant modifyDate)
    {
-      return label;
-   }
-
-
-
-   /*******************************************************************************
-    ** Setter for label
-    **
-    *******************************************************************************/
-   public void setLabel(String label)
-   {
-      this.label = label;
-   }
-
-
-
-   /*******************************************************************************
-    ** Fluent setter for label
-    **
-    *******************************************************************************/
-   public SavedView withLabel(String label)
-   {
-      this.label = label;
+      this.modifyDate = modifyDate;
       return (this);
    }
 
 
 
    /*******************************************************************************
-    ** Getter for tableName
-    **
+    * Getter for savedViewId
+    * @see #withSavedViewId(Integer)
     *******************************************************************************/
-   public String getTableName()
+   public Integer getSavedViewId()
    {
-      return tableName;
+      return (this.savedViewId);
    }
 
 
 
    /*******************************************************************************
-    ** Setter for tableName
-    **
+    * Setter for savedViewId
+    * @see #withSavedViewId(Integer)
     *******************************************************************************/
-   public void setTableName(String tableName)
+   public void setSavedViewId(Integer savedViewId)
    {
-      this.tableName = tableName;
+      this.savedViewId = savedViewId;
    }
 
 
 
    /*******************************************************************************
-    ** Fluent setter for tableName
-    **
+    * Fluent setter for savedViewId
+    *
+    * @param savedViewId
+    * id of the saved view that this quick saved view refers to
+    * @return this
     *******************************************************************************/
-   public SavedView withTableName(String tableName)
+   public QuickSavedView withSavedViewId(Integer savedViewId)
    {
-      this.tableName = tableName;
+      this.savedViewId = savedViewId;
       return (this);
    }
 
 
 
    /*******************************************************************************
-    ** Getter for userId
-    **
+    * Getter for sortOrder
+    * @see #withSortOrder(Integer)
+    *******************************************************************************/
+   public Integer getSortOrder()
+   {
+      return (this.sortOrder);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for sortOrder
+    * @see #withSortOrder(Integer)
+    *******************************************************************************/
+   public void setSortOrder(Integer sortOrder)
+   {
+      this.sortOrder = sortOrder;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for sortOrder
+    *
+    * @param sortOrder
+    * Integer to control the sort-order for the user's quick saved views.
+    * @return this
+    *******************************************************************************/
+   public QuickSavedView withSortOrder(Integer sortOrder)
+   {
+      this.sortOrder = sortOrder;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for doCount
+    * @see #withDoCount(Boolean)
+    *******************************************************************************/
+   public Boolean getDoCount()
+   {
+      return (this.doCount);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for doCount
+    * @see #withDoCount(Boolean)
+    *******************************************************************************/
+   public void setDoCount(Boolean doCount)
+   {
+      this.doCount = doCount;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for doCount
+    *
+    * @param doCount
+    * boolean to specify whether or not the frontend should execute a count whenever
+    * it displays a button for this quick saved view.
+    * @return this
+    *******************************************************************************/
+   public QuickSavedView withDoCount(Boolean doCount)
+   {
+      this.doCount = doCount;
+      return (this);
+   }
+
+
+   /*******************************************************************************
+    * Getter for userId
+    * @see #withUserId(String)
     *******************************************************************************/
    public String getUserId()
    {
-      return userId;
+      return (this.userId);
    }
 
 
 
    /*******************************************************************************
-    ** Setter for userId
-    **
+    * Setter for userId
+    * @see #withUserId(String)
     *******************************************************************************/
    public void setUserId(String userId)
    {
@@ -237,44 +333,17 @@ public class SavedView extends QRecordEntity
 
 
    /*******************************************************************************
-    ** Fluent setter for userId
-    **
+    * Fluent setter for userId
+    *
+    * @param userId
+    * TODO document this property
+    * @return this
     *******************************************************************************/
-   public SavedView withUserId(String userId)
+   public QuickSavedView withUserId(String userId)
    {
       this.userId = userId;
       return (this);
    }
 
-
-
-   /*******************************************************************************
-    ** Getter for viewJson
-    *******************************************************************************/
-   public String getViewJson()
-   {
-      return (this.viewJson);
-   }
-
-
-
-   /*******************************************************************************
-    ** Setter for viewJson
-    *******************************************************************************/
-   public void setViewJson(String viewJson)
-   {
-      this.viewJson = viewJson;
-   }
-
-
-
-   /*******************************************************************************
-    ** Fluent setter for viewJson
-    *******************************************************************************/
-   public SavedView withViewJson(String viewJson)
-   {
-      this.viewJson = viewJson;
-      return (this);
-   }
 
 }

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/savedviews/SavedViewsMetaDataProvider.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/savedviews/SavedViewsMetaDataProvider.java
@@ -232,14 +232,14 @@ public class SavedViewsMetaDataProvider
          .withLabel("Quick View")
          .withIcon(new QIcon().withName("dynamic_form"))
          .withRecordLabelFormat("%s")
-         .withRecordLabelFields("savedViewId")
+         .withRecordLabelFields("label")
          .withBackendName(backendName)
          .withPrimaryKeyField("id")
          .withUniqueKey(new UniqueKey("savedViewId", "userId"))
          .withFieldsFromEntity(QuickSavedView.class)
          .withRecordSecurityLock(userLevelRecordSecurityLock)
          .withAuditRules(new QAuditRules().withAuditLevel(AuditLevel.FIELD))
-         .withSection(new QFieldSection("identity", new QIcon().withName("badge"), Tier.T1, List.of("id", "savedViewId")))
+         .withSection(new QFieldSection("identity", new QIcon().withName("badge"), Tier.T1, List.of("id", "label", "savedViewId")))
          .withSection(new QFieldSection("data", new QIcon().withName("text_snippet"), Tier.T2, List.of("userId", "sortOrder", "doCount")))
          .withSection(new QFieldSection("dates", new QIcon().withName("calendar_month"), Tier.T3, List.of("createDate", "modifyDate")));
 

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/savedviews/SavedViewsMetaDataProvider.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/savedviews/SavedViewsMetaDataProvider.java
@@ -39,6 +39,8 @@ import com.kingsrook.qqq.backend.core.model.metadata.layout.QIcon;
 import com.kingsrook.qqq.backend.core.model.metadata.possiblevalues.PVSValueFormatAndFields;
 import com.kingsrook.qqq.backend.core.model.metadata.possiblevalues.QPossibleValueSource;
 import com.kingsrook.qqq.backend.core.model.metadata.possiblevalues.QPossibleValueSourceType;
+import com.kingsrook.qqq.backend.core.model.metadata.security.MultiRecordSecurityLock;
+import com.kingsrook.qqq.backend.core.model.metadata.security.RecordSecurityLock;
 import com.kingsrook.qqq.backend.core.model.metadata.sharing.ShareScopePossibleValueMetaDataProducer;
 import com.kingsrook.qqq.backend.core.model.metadata.tables.QFieldSection;
 import com.kingsrook.qqq.backend.core.model.metadata.tables.QTableMetaData;
@@ -50,11 +52,29 @@ import com.kingsrook.qqq.backend.core.processes.implementations.savedviews.Store
 
 
 /*******************************************************************************
- **
+ * Define MetaData for the Shared Views functionality.
+ *
+ * <p>Optionally, sharing can be enabled (so a view created by one user can be
+ * seen by other users (and or groups, etc, as defined by app-level customizations).
+ * Similarly, an alternative presentation of some views as "Quick Saved Views" can
+ * be enabled (e.g., show quick ones as one-tap buttons, vs. the rest in a dropdown
+ * menu).</p>
+ *
+ * <p>An optional {@link RecordSecurityLock} is encouraged to be provided, to apply
+ * to the {@link SharedSavedView} and {@link QuickSavedView} tables.  This can be
+ * used to control access to these entities.  Applications may add additional fields
+ * to these tables for custom security locks (in which case, they will need to
+ * put their own {@link RecordSecurityLock} on the tables.</p>
  *******************************************************************************/
 public class SavedViewsMetaDataProvider
 {
    public static final String SHARED_SAVED_VIEW_JOIN_SAVED_VIEW = "sharedSavedViewJoinSavedView";
+   public static final String QUICK_SAVED_VIEW_JOIN_SAVED_VIEW = "quickSavedViewJoinSavedView";
+
+   private boolean isShareSavedViewEnabled = true;
+   private boolean isQuickSavedViewEnabled = false;
+
+   private RecordSecurityLock userLevelRecordSecurityLock = null;
 
 
    /*******************************************************************************
@@ -68,14 +88,20 @@ public class SavedViewsMetaDataProvider
       instance.addProcess(StoreSavedViewProcess.getProcessMetaData());
       instance.addProcess(DeleteSavedViewProcess.getProcessMetaData());
 
-      /////////////////////////////////////
-      // todo - param to enable sharing? //
-      /////////////////////////////////////
-      instance.addTable(defineSharedSavedViewTable(backendName, backendDetailEnricher));
-      instance.addJoin(defineSharedSavedViewJoinSavedView());
-      if(instance.getPossibleValueSource(ShareScopePossibleValueMetaDataProducer.NAME) == null)
+      if(isShareSavedViewEnabled)
       {
-         instance.addPossibleValueSource(new ShareScopePossibleValueMetaDataProducer().produce(new QInstance()));
+         instance.addTable(defineSharedSavedViewTable(backendName, backendDetailEnricher));
+         instance.addJoin(defineSharedSavedViewJoinSavedView());
+         if(instance.getPossibleValueSource(ShareScopePossibleValueMetaDataProducer.NAME) == null)
+         {
+            instance.addPossibleValueSource(new ShareScopePossibleValueMetaDataProducer().produce(new QInstance()));
+         }
+      }
+
+      if(isQuickSavedViewEnabled)
+      {
+         instance.addTable(defineQuickSavedViewTable(backendName, backendDetailEnricher));
+         instance.addJoin(defineQuickSavedViewJoinSavedView());
       }
    }
 
@@ -86,6 +112,26 @@ public class SavedViewsMetaDataProvider
     *******************************************************************************/
    public QTableMetaData defineSavedViewTable(String backendName, Consumer<QTableMetaData> backendDetailEnricher) throws QException
    {
+      RecordSecurityLock lock = null;
+      if(userLevelRecordSecurityLock != null)
+      {
+         if(isShareSavedViewEnabled)
+         {
+            RecordSecurityLock sharedUserIdLock = userLevelRecordSecurityLock.clone();
+            sharedUserIdLock.setFieldName(SharedSavedView.TABLE_NAME + ".userId");
+            sharedUserIdLock.setJoinNameChain(List.of(SHARED_SAVED_VIEW_JOIN_SAVED_VIEW));
+
+            lock = new MultiRecordSecurityLock()
+               .withOperator(MultiRecordSecurityLock.BooleanOperator.OR)
+               .withLock(userLevelRecordSecurityLock)
+               .withLock(sharedUserIdLock);
+         }
+         else
+         {
+            lock = userLevelRecordSecurityLock;
+         }
+      }
+
       QTableMetaData table = new QTableMetaData()
          .withName(SavedView.TABLE_NAME)
          .withLabel("View")
@@ -95,6 +141,7 @@ public class SavedViewsMetaDataProvider
          .withBackendName(backendName)
          .withPrimaryKeyField("id")
          .withFieldsFromEntity(SavedView.class)
+         .withRecordSecurityLock(lock)
          .withSection(new QFieldSection("identity", new QIcon().withName("badge"), Tier.T1, List.of("id", "label")))
          .withSection(new QFieldSection("data", new QIcon().withName("text_snippet"), Tier.T2, List.of("userId", "tableName", "viewJson")))
          .withSection(new QFieldSection("dates", new QIcon().withName("calendar_month"), Tier.T3, List.of("createDate", "modifyDate")));
@@ -144,7 +191,7 @@ public class SavedViewsMetaDataProvider
          .withUniqueKey(new UniqueKey("savedViewId", "userId"))
          .withPrimaryKeyField("id")
          .withFieldsFromEntity(SharedSavedView.class)
-         // todo - security key
+         .withRecordSecurityLock(userLevelRecordSecurityLock)
          .withAuditRules(new QAuditRules().withAuditLevel(AuditLevel.FIELD))
          .withSection(new QFieldSection("identity", new QIcon().withName("badge"), Tier.T1, List.of("id", "savedViewId", "userId")))
          .withSection(new QFieldSection("data", new QIcon().withName("text_snippet"), Tier.T2, List.of("scope")))
@@ -172,5 +219,164 @@ public class SavedViewsMetaDataProvider
          .withType(JoinType.MANY_TO_ONE)
          .withJoinOn(new JoinOn("savedViewId", "id")));
    }
+
+
+
+   /***************************************************************************
+    *
+    ***************************************************************************/
+   private QTableMetaData defineQuickSavedViewTable(String backendName, Consumer<QTableMetaData> backendDetailEnricher) throws QException
+   {
+      QTableMetaData table = new QTableMetaData()
+         .withName(QuickSavedView.TABLE_NAME)
+         .withLabel("Quick View")
+         .withIcon(new QIcon().withName("dynamic_form"))
+         .withRecordLabelFormat("%s")
+         .withRecordLabelFields("savedViewId")
+         .withBackendName(backendName)
+         .withPrimaryKeyField("id")
+         .withUniqueKey(new UniqueKey("savedViewId", "userId"))
+         .withFieldsFromEntity(QuickSavedView.class)
+         .withRecordSecurityLock(userLevelRecordSecurityLock)
+         .withAuditRules(new QAuditRules().withAuditLevel(AuditLevel.FIELD))
+         .withSection(new QFieldSection("identity", new QIcon().withName("badge"), Tier.T1, List.of("id", "savedViewId")))
+         .withSection(new QFieldSection("data", new QIcon().withName("text_snippet"), Tier.T2, List.of("userId", "sortOrder", "doCount")))
+         .withSection(new QFieldSection("dates", new QIcon().withName("calendar_month"), Tier.T3, List.of("createDate", "modifyDate")));
+
+      if(backendDetailEnricher != null)
+      {
+         backendDetailEnricher.accept(table);
+      }
+
+      return (table);
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   private QJoinMetaData defineQuickSavedViewJoinSavedView()
+   {
+      return (new QJoinMetaData()
+         .withName(QUICK_SAVED_VIEW_JOIN_SAVED_VIEW)
+         .withLeftTable(QuickSavedView.TABLE_NAME)
+         .withRightTable(SavedView.TABLE_NAME)
+         .withType(JoinType.MANY_TO_ONE)
+         .withJoinOn(new JoinOn("savedViewId", "id")));
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for isQuickSavedViewEnabled
+    * @see #withIsQuickSavedViewEnabled(boolean)
+    *******************************************************************************/
+   public boolean getIsQuickSavedViewEnabled()
+   {
+      return (this.isQuickSavedViewEnabled);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for isQuickSavedViewEnabled
+    * @see #withIsQuickSavedViewEnabled(boolean)
+    *******************************************************************************/
+   public void setIsQuickSavedViewEnabled(boolean isQuickSavedViewEnabled)
+   {
+      this.isQuickSavedViewEnabled = isQuickSavedViewEnabled;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for isQuickSavedViewEnabled
+    *
+    * @param isQuickSavedViewEnabled
+    * Controls if, when defineAll is called, whether to include Quick Saved Views
+    * in the metadata definition.  default value is false
+    * @return this
+    *******************************************************************************/
+   public SavedViewsMetaDataProvider withIsQuickSavedViewEnabled(boolean isQuickSavedViewEnabled)
+   {
+      this.isQuickSavedViewEnabled = isQuickSavedViewEnabled;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for isShareSavedViewEnabled
+    * @see #withIsShareSavedViewEnabled(boolean)
+    *******************************************************************************/
+   public boolean getIsShareSavedViewEnabled()
+   {
+      return (this.isShareSavedViewEnabled);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for isShareSavedViewEnabled
+    * @see #withIsShareSavedViewEnabled(boolean)
+    *******************************************************************************/
+   public void setIsShareSavedViewEnabled(boolean isShareSavedViewEnabled)
+   {
+      this.isShareSavedViewEnabled = isShareSavedViewEnabled;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for isShareSavedViewEnabled
+    *
+    * @param isShareSavedViewEnabled
+    * Controls if, when defineAll is called, whether to include Shared Saved Views
+    * in the metadata definition.  default value is true.
+    * @return this
+    *******************************************************************************/
+   public SavedViewsMetaDataProvider withIsShareSavedViewEnabled(boolean isShareSavedViewEnabled)
+   {
+      this.isShareSavedViewEnabled = isShareSavedViewEnabled;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for userLevelRecordSecurityLock
+    * @see #withUserLevelRecordSecurityLock(RecordSecurityLock)
+    *******************************************************************************/
+   public RecordSecurityLock getUserLevelRecordSecurityLock()
+   {
+      return (this.userLevelRecordSecurityLock);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for userLevelRecordSecurityLock
+    * @see #withUserLevelRecordSecurityLock(RecordSecurityLock)
+    *******************************************************************************/
+   public void setUserLevelRecordSecurityLock(RecordSecurityLock userLevelRecordSecurityLock)
+   {
+      this.userLevelRecordSecurityLock = userLevelRecordSecurityLock;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for userLevelRecordSecurityLock
+    *
+    * @param userLevelRecordSecurityLock
+    * @return this
+    *******************************************************************************/
+   public SavedViewsMetaDataProvider withUserLevelRecordSecurityLock(RecordSecurityLock userLevelRecordSecurityLock)
+   {
+      this.userLevelRecordSecurityLock = userLevelRecordSecurityLock;
+      return (this);
+   }
+
 
 }

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/processes/implementations/savedviews/QuerySavedViewProcess.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/processes/implementations/savedviews/QuerySavedViewProcess.java
@@ -24,10 +24,12 @@ package com.kingsrook.qqq.backend.core.processes.implementations.savedviews;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 import com.kingsrook.qqq.backend.core.actions.ActionHelper;
 import com.kingsrook.qqq.backend.core.actions.processes.BackendStep;
 import com.kingsrook.qqq.backend.core.actions.tables.GetAction;
 import com.kingsrook.qqq.backend.core.actions.tables.QueryAction;
+import com.kingsrook.qqq.backend.core.context.QContext;
 import com.kingsrook.qqq.backend.core.exceptions.QException;
 import com.kingsrook.qqq.backend.core.exceptions.QNotFoundException;
 import com.kingsrook.qqq.backend.core.logging.QLogger;
@@ -41,10 +43,14 @@ import com.kingsrook.qqq.backend.core.model.actions.tables.query.QFilterOrderBy;
 import com.kingsrook.qqq.backend.core.model.actions.tables.query.QQueryFilter;
 import com.kingsrook.qqq.backend.core.model.actions.tables.query.QueryInput;
 import com.kingsrook.qqq.backend.core.model.actions.tables.query.QueryOutput;
+import com.kingsrook.qqq.backend.core.model.data.QRecord;
 import com.kingsrook.qqq.backend.core.model.metadata.code.QCodeReference;
 import com.kingsrook.qqq.backend.core.model.metadata.processes.QBackendStepMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.processes.QProcessMetaData;
+import com.kingsrook.qqq.backend.core.model.savedviews.QuickSavedView;
 import com.kingsrook.qqq.backend.core.model.savedviews.SavedView;
+import com.kingsrook.qqq.backend.core.utils.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import static com.kingsrook.qqq.backend.core.logging.LogUtils.logPair;
 
 
@@ -111,8 +117,18 @@ public class QuerySavedViewProcess implements BackendStep
                .withOrderBy(new QFilterOrderBy("label")));
 
             QueryOutput output = new QueryAction().execute(input);
-            runBackendStepOutput.setRecords(output.getRecords());
-            runBackendStepOutput.addValue("savedViewList", (Serializable) output.getRecords());
+            List<QRecord> savedViewRecords = output.getRecords();
+
+            /////////////////////////////////////////////////////////////////////////////////////
+            // possibly add data to the saved views for "quick views"                          //
+            // note, we'll call this even if we didn't find any savedViewRecords, just in case //
+            // an application wants to sub-class this process step, to, for example, hard-code //
+            // some quick-views that get returned even if a user doesn't have any saved views  //
+            /////////////////////////////////////////////////////////////////////////////////////
+            lookupQuickViews(runBackendStepInput, savedViewRecords);
+
+            runBackendStepOutput.setRecords(savedViewRecords);
+            runBackendStepOutput.addValue("savedViewList", (Serializable) savedViewRecords);
          }
       }
       catch(QNotFoundException qnfe)
@@ -126,4 +142,63 @@ public class QuerySavedViewProcess implements BackendStep
          throw (e);
       }
    }
+
+
+
+   /***************************************************************************
+    * If the qInstance has a {@link QuickSavedView} table, then query for
+    * quick-saved view records associated with the list of saved view records
+    * that were found.
+    *
+    * <p>If corresponding {@link QuickSavedView}'s are found, then update the
+    * saved-view records with the following values from the QuickSavedView:</p>
+    * <ul>
+    *    <li>type = "quickSavedView"</li>
+    *    <li>doCount = boolean from the QuickSavedView</li>
+    *    <li>sortOrder = integer sortOrder from the QuickSavedView</li>
+    * </ul>
+    ***************************************************************************/
+   protected void lookupQuickViews(RunBackendStepInput runBackendStepInput, List<QRecord> savedViewRecords) throws QException
+   {
+      ////////////////////////////////////////////////////////////
+      // if there's no quick saved view table, return with noop //
+      ////////////////////////////////////////////////////////////
+      if(QContext.getQInstance().getTable(QuickSavedView.TABLE_NAME) == null)
+      {
+         return;
+      }
+
+      if(CollectionUtils.nullSafeIsEmpty(savedViewRecords))
+      {
+         return;
+      }
+
+      List<Integer> savedViewIds = savedViewRecords.stream().map(r -> r.getValueInteger("id")).toList();
+
+      ///////////////////////////////////////////////////////////////////////////////////////
+      // given that, based on sharing rules, multiple quick view records might be found    //
+      // for a given saved view. sort this query in a predictable manner (noting that rows //
+      // will be iterated over, and the last one found for a particular saved view is the  //
+      // one that will apply).  So sort by sortOrder descending, (so the lowest value will //
+      // be used), then by id ascending (so more recently added ones would be preferred)   //
+      ///////////////////////////////////////////////////////////////////////////////////////
+      List<QRecord> quickSavedViews = QueryAction.execute(QuickSavedView.TABLE_NAME, new QQueryFilter()
+         .withCriteria(new QFilterCriteria("savedViewId", QCriteriaOperator.IN, savedViewIds))
+         .withOrderBy(new QFilterOrderBy("sortOrder", false))
+         .withOrderBy(new QFilterOrderBy("id", true)));
+
+      Map<Integer, QRecord> quickSavedViewsBySavedViewIdMap = CollectionUtils.listToMap(quickSavedViews, r -> r.getValueInteger("savedViewId"), r -> r);
+      for(QRecord savedViewRecord : savedViewRecords)
+      {
+         QRecord quickSavedViewRecord = quickSavedViewsBySavedViewIdMap.get(savedViewRecord.getValueInteger("id"));
+         if(quickSavedViewRecord != null)
+         {
+            savedViewRecord.setValue("type", "quickView");
+            savedViewRecord.setValue("doCount", BooleanUtils.isTrue(quickSavedViewRecord.getValueBoolean("doCount")));
+            savedViewRecord.setValue("sortOrder", quickSavedViewRecord.getValueInteger("sortOrder"));
+         }
+      }
+
+   }
+
 }

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/processes/implementations/savedviews/QuerySavedViewProcess.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/processes/implementations/savedviews/QuerySavedViewProcess.java
@@ -50,6 +50,7 @@ import com.kingsrook.qqq.backend.core.model.metadata.processes.QProcessMetaData;
 import com.kingsrook.qqq.backend.core.model.savedviews.QuickSavedView;
 import com.kingsrook.qqq.backend.core.model.savedviews.SavedView;
 import com.kingsrook.qqq.backend.core.utils.CollectionUtils;
+import com.kingsrook.qqq.backend.core.utils.StringUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import static com.kingsrook.qqq.backend.core.logging.LogUtils.logPair;
 
@@ -196,6 +197,11 @@ public class QuerySavedViewProcess implements BackendStep
             savedViewRecord.setValue("type", "quickView");
             savedViewRecord.setValue("doCount", BooleanUtils.isTrue(quickSavedViewRecord.getValueBoolean("doCount")));
             savedViewRecord.setValue("sortOrder", quickSavedViewRecord.getValueInteger("sortOrder"));
+
+            if(StringUtils.hasContent(quickSavedViewRecord.getValueString("label")))
+            {
+               savedViewRecord.setValue("label", quickSavedViewRecord.getValueString("label"));
+            }
          }
       }
 

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/processes/implementations/savedviews/QuerySavedViewProcessTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/processes/implementations/savedviews/QuerySavedViewProcessTest.java
@@ -122,12 +122,13 @@ class QuerySavedViewProcessTest extends BaseTest
       ///////////////////////////////////////////////////////////
       {
          new InsertAction().execute(new InsertInput(QuickSavedView.TABLE_NAME).withRecordEntity(
-            new QuickSavedView().withSavedViewId(savedView0Id).withDoCount(true).withSortOrder(17)));
+            new QuickSavedView().withLabel("Quickly").withSavedViewId(savedView0Id).withDoCount(true).withSortOrder(17)));
          List<QRecord> savedViewList = runQuerySavedViewsProcess(tableName);
          assertEquals(1, savedViewList.size());
 
          QRecord savedView0 = savedViewList.get(0);
          assertEquals("quickView", savedView0.getValue("type"));
+         assertEquals("Quickly", savedView0.getValue("label"));
          assertTrue(savedView0.getValueBoolean("doCount"));
          assertEquals(17, savedView0.getValue("sortOrder"));
       }
@@ -137,7 +138,7 @@ class QuerySavedViewProcessTest extends BaseTest
       //////////////////////////////////////////////////////////////////////////////////////////////
       {
          new InsertAction().execute(new InsertInput(QuickSavedView.TABLE_NAME).withRecordEntity(
-            new QuickSavedView().withSavedViewId(savedView0Id + 1).withDoCount(true).withSortOrder(17)));
+            new QuickSavedView().withLabel("Second").withSavedViewId(savedView0Id + 1).withDoCount(true).withSortOrder(17)));
          List<QRecord> savedViewList = runQuerySavedViewsProcess(tableName);
          assertEquals(1, savedViewList.size());
       }

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/processes/implementations/savedviews/QuerySavedViewProcessTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/processes/implementations/savedviews/QuerySavedViewProcessTest.java
@@ -1,0 +1,342 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.processes.implementations.savedviews;
+
+
+import java.util.List;
+import java.util.Map;
+import com.kingsrook.qqq.backend.core.BaseTest;
+import com.kingsrook.qqq.backend.core.actions.processes.RunProcessAction;
+import com.kingsrook.qqq.backend.core.actions.tables.InsertAction;
+import com.kingsrook.qqq.backend.core.context.QContext;
+import com.kingsrook.qqq.backend.core.exceptions.QException;
+import com.kingsrook.qqq.backend.core.model.actions.processes.RunBackendStepInput;
+import com.kingsrook.qqq.backend.core.model.actions.processes.RunProcessInput;
+import com.kingsrook.qqq.backend.core.model.actions.processes.RunProcessOutput;
+import com.kingsrook.qqq.backend.core.model.actions.tables.insert.InsertInput;
+import com.kingsrook.qqq.backend.core.model.data.QRecord;
+import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
+import com.kingsrook.qqq.backend.core.model.metadata.code.QCodeReference;
+import com.kingsrook.qqq.backend.core.model.metadata.processes.QBackendStepMetaData;
+import com.kingsrook.qqq.backend.core.model.metadata.processes.QStepMetaData;
+import com.kingsrook.qqq.backend.core.model.metadata.security.QSecurityKeyType;
+import com.kingsrook.qqq.backend.core.model.metadata.security.RecordSecurityLock;
+import com.kingsrook.qqq.backend.core.model.savedviews.QuickSavedView;
+import com.kingsrook.qqq.backend.core.model.savedviews.SavedView;
+import com.kingsrook.qqq.backend.core.model.savedviews.SavedViewsMetaDataProvider;
+import com.kingsrook.qqq.backend.core.model.savedviews.SharedSavedView;
+import com.kingsrook.qqq.backend.core.modules.backend.implementations.memory.MemoryRecordStore;
+import com.kingsrook.qqq.backend.core.utils.TestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/*******************************************************************************
+ ** Unit test for QuerySavedViewProcess 
+ *******************************************************************************/
+class QuerySavedViewProcessTest extends BaseTest
+{
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @BeforeEach
+   void beforeEach()
+   {
+      MemoryRecordStore.getInstance().setBuildJoinCrossProductFromJoinContext(true);
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @AfterEach
+   void afterEach()
+   {
+      MemoryRecordStore.getInstance().setBuildJoinCrossProductFromJoinContext(MemoryRecordStore.BUILD_JOIN_CROSS_PRODUCT_FROM_JOIN_CONTEXT_DEFAULT);
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testQuickSavedViews() throws Exception
+   {
+      QInstance qInstance = QContext.getQInstance();
+      new SavedViewsMetaDataProvider()
+         .withIsQuickSavedViewEnabled(true)
+         .defineAll(qInstance, TestUtils.MEMORY_BACKEND_NAME, null);
+      String tableName = TestUtils.TABLE_NAME_PERSON_MEMORY;
+
+      //////////////////////////////////////////////
+      // start with nothing saved, empty use-case //
+      //////////////////////////////////////////////
+      {
+         List<QRecord> savedViewList = runQuerySavedViewsProcess(tableName);
+         assertEquals(0, savedViewList.size());
+      }
+
+      /////////////////////////////////////////////////////
+      // insert one saved view, but no quick saved views //
+      /////////////////////////////////////////////////////
+      Integer savedView0Id;
+      {
+         new InsertAction().execute(new InsertInput(SavedView.TABLE_NAME).withRecordEntity(
+            new SavedView().withTableName(tableName).withLabel("one").withUserId(QContext.getQSession().getUser().getIdReference())));
+         List<QRecord> savedViewList = runQuerySavedViewsProcess(tableName);
+         assertEquals(1, savedViewList.size());
+
+         QRecord savedView0 = savedViewList.get(0);
+         assertNull(savedView0.getValue("type"));
+         savedView0Id = savedView0.getValueInteger("id");
+      }
+
+      ///////////////////////////////////////////////////////////
+      // insert a quick saved view referencing that saved view //
+      ///////////////////////////////////////////////////////////
+      {
+         new InsertAction().execute(new InsertInput(QuickSavedView.TABLE_NAME).withRecordEntity(
+            new QuickSavedView().withSavedViewId(savedView0Id).withDoCount(true).withSortOrder(17)));
+         List<QRecord> savedViewList = runQuerySavedViewsProcess(tableName);
+         assertEquals(1, savedViewList.size());
+
+         QRecord savedView0 = savedViewList.get(0);
+         assertEquals("quickView", savedView0.getValue("type"));
+         assertTrue(savedView0.getValueBoolean("doCount"));
+         assertEquals(17, savedView0.getValue("sortOrder"));
+      }
+
+      //////////////////////////////////////////////////////////////////////////////////////////////
+      // insert a 2nd quick saved view, referencing a non-existing saved view (should be ignored) //
+      //////////////////////////////////////////////////////////////////////////////////////////////
+      {
+         new InsertAction().execute(new InsertInput(QuickSavedView.TABLE_NAME).withRecordEntity(
+            new QuickSavedView().withSavedViewId(savedView0Id + 1).withDoCount(true).withSortOrder(17)));
+         List<QRecord> savedViewList = runQuerySavedViewsProcess(tableName);
+         assertEquals(1, savedViewList.size());
+      }
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testQuerySavedViewProcessWithoutQuickSavedViewsInInstance() throws Exception
+   {
+      QInstance qInstance = QContext.getQInstance();
+      new SavedViewsMetaDataProvider()
+         .withIsQuickSavedViewEnabled(false)
+         .defineAll(qInstance, TestUtils.MEMORY_BACKEND_NAME, null);
+      String tableName = TestUtils.TABLE_NAME_PERSON_MEMORY;
+
+      //////////////////////////////////////////////
+      // start with nothing saved, empty use-case //
+      //////////////////////////////////////////////
+      {
+         List<QRecord> savedViewList = runQuerySavedViewsProcess(tableName);
+         assertEquals(0, savedViewList.size());
+      }
+
+      /////////////////////////////////////////////////
+      // insert one saved view, make sure that works //
+      /////////////////////////////////////////////////
+      {
+         new InsertAction().execute(new InsertInput(SavedView.TABLE_NAME).withRecordEntity(
+            new SavedView().withTableName(tableName).withLabel("one").withUserId(QContext.getQSession().getUser().getIdReference())));
+         List<QRecord> savedViewList = runQuerySavedViewsProcess(tableName);
+         assertEquals(1, savedViewList.size());
+
+         QRecord savedView0 = savedViewList.get(0);
+         assertNull(savedView0.getValue("type"));
+      }
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testApplicationCanOverrideLookupQuickViewsMethod() throws Exception
+   {
+      QInstance qInstance = QContext.getQInstance();
+      new SavedViewsMetaDataProvider()
+         .withIsQuickSavedViewEnabled(false)
+         .defineAll(qInstance, TestUtils.MEMORY_BACKEND_NAME, null);
+      String tableName = TestUtils.TABLE_NAME_PERSON_MEMORY;
+
+      {
+         /////////////////////////////////////
+         // baseline - no saved views exist //
+         /////////////////////////////////////
+         List<QRecord> savedViewList = runQuerySavedViewsProcess(tableName);
+         assertEquals(0, savedViewList.size());
+      }
+
+      ////////////////////////////////////////
+      // update the process to use our code //
+      ////////////////////////////////////////
+      QStepMetaData step = QContext.getQInstance().getProcess(QuerySavedViewProcess.getProcessMetaData().getName())
+         .getStepList().get(0);
+      ((QBackendStepMetaData) step).setCode(new QCodeReference(CustomQuerySavedViewProcessStep.class));
+
+      {
+         //////////////////////////////////////////////////
+         // now we get a custom quick-view in the output //
+         //////////////////////////////////////////////////
+         List<QRecord> savedViewList = runQuerySavedViewsProcess(tableName);
+         assertEquals(1, savedViewList.size());
+         QRecord savedView0 = savedViewList.get(0);
+         assertEquals(tableName, savedView0.getValue("tableName"));
+         assertEquals("Custom Quick View", savedView0.getValue("label"));
+         assertEquals("quickView", savedView0.getValue("type"));
+      }
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testUserIdLock() throws Exception
+   {
+      String tableName        = TestUtils.TABLE_NAME_PERSON_MEMORY;
+      String keyType          = "userId";
+      String allAccessKeyType = "userIdAllAccess";
+
+      ////////////////////////////////////////////////////////////////////////////////////////////
+      // define a key type and a lock - then send that lock into the SavedViewsMetaDataProvider //
+      ////////////////////////////////////////////////////////////////////////////////////////////
+      QInstance qInstance = QContext.getQInstance();
+
+      qInstance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(keyType)
+         .withAllAccessKeyName(allAccessKeyType));
+
+      RecordSecurityLock securityLock = new RecordSecurityLock()
+         .withFieldName("userId")
+         .withSecurityKeyType(keyType);
+
+      new SavedViewsMetaDataProvider()
+         .withIsShareSavedViewEnabled(true)
+         .withIsQuickSavedViewEnabled(true)
+         .withUserLevelRecordSecurityLock(securityLock)
+         .defineAll(qInstance, TestUtils.MEMORY_BACKEND_NAME, null);
+
+      ///////////////////////////////////////////////////////
+      // insert 3 views, one for each of 3 different users //
+      ///////////////////////////////////////////////////////
+      QContext.getQSession().withSecurityKeyValues(Map.of(allAccessKeyType, List.of(true)));
+      List<QRecord> insertedSavedViews = new InsertAction().execute(new InsertInput(SavedView.TABLE_NAME).withRecordEntities(List.of(
+         new SavedView().withLabel("Jim's").withUserId("jim").withTableName(tableName),
+         new SavedView().withLabel("Jean's").withUserId("jean").withTableName(tableName),
+         new SavedView().withLabel("Ben's").withUserId("ben").withTableName(tableName)
+      ))).getRecords();
+      Integer jeansViewId = insertedSavedViews.get(1).getValueInteger("id");
+
+      {
+         //////////////////////////////////////////////////
+         // as user with allAccessKeyType, see all views //
+         //////////////////////////////////////////////////
+         QContext.getQSession().withSecurityKeyValues(Map.of(allAccessKeyType, List.of(true)));
+         List<QRecord> records = runQuerySavedViewsProcess(tableName);
+         assertEquals(3, records.size());
+      }
+
+      {
+         /////////////////////////////////////////////////////
+         // as an individual user, only see their own views //
+         /////////////////////////////////////////////////////
+         QContext.getQSession().withSecurityKeyValues(Map.of(keyType, List.of("jim")));
+         List<QRecord> records = runQuerySavedViewsProcess(tableName);
+         assertEquals(1, records.size());
+         assertEquals("Jim's", records.get(0).getValue("label"));
+      }
+
+      {
+         /////////////////////////////////////////////////////////////////////////////
+         // now build a share of jean's view to ben                                 //
+         // todo - a flaw we have is, jean can't insert a record to share to ben... //
+         /////////////////////////////////////////////////////////////////////////////
+         QContext.getQSession().withSecurityKeyValues(Map.of(allAccessKeyType, List.of(true)));
+         new InsertAction().execute(new InsertInput(SharedSavedView.TABLE_NAME).withRecordEntity(
+            new SharedSavedView().withSavedViewId(jeansViewId).withUserId("ben")));
+
+         ///////////////////////////////////////////////////
+         // then, as ben, run the process and get 2 views //
+         ///////////////////////////////////////////////////
+         QContext.getQSession().withSecurityKeyValues(Map.of(keyType, List.of("ben")));
+         List<QRecord> records = runQuerySavedViewsProcess(tableName);
+         assertEquals(2, records.size());
+         assertEquals("Ben's", records.get(0).getValue("label"));
+         assertEquals("Jean's", records.get(1).getValue("label"));
+      }
+   }
+
+
+
+   /***************************************************************************
+    *
+    ***************************************************************************/
+   private static List<QRecord> runQuerySavedViewsProcess(String tableName) throws QException
+   {
+      RunProcessInput runProcessInput = new RunProcessInput();
+      runProcessInput.setProcessName(QuerySavedViewProcess.getProcessMetaData().getName());
+      runProcessInput.addValue("tableName", tableName);
+      RunProcessOutput runProcessOutput = new RunProcessAction().execute(runProcessInput);
+      List<QRecord>    savedViewList    = (List<QRecord>) runProcessOutput.getValue("savedViewList");
+      return savedViewList;
+   }
+
+
+
+   /***************************************************************************
+    * test overriding the {@link QuerySavedViewProcess} step, to do special logic
+    * for quick views.
+    ***************************************************************************/
+   public static class CustomQuerySavedViewProcessStep extends QuerySavedViewProcess
+   {
+      /***************************************************************************
+       *
+       ***************************************************************************/
+      @Override
+      protected void lookupQuickViews(RunBackendStepInput runBackendStepInput, List<QRecord> savedViewRecords) throws QException
+      {
+         savedViewRecords.add(new SavedView()
+            .withTableName(runBackendStepInput.getValueString("tableName"))
+            .withLabel("Custom Quick View")
+            .toQRecord()
+            .withValue("type", "quickView")
+         );
+      }
+   }
+}


### PR DESCRIPTION
## Summary

Introduces **Quick Saved Views** — a layer on top of Saved Views that enables frontends to present certain views with special, faster access (e.g., pinned views with optional record counts).

- New `QuickSavedView` entity with per-user settings (`sortOrder`, `doCount`) linked many-to-one to `SavedView`
- `SavedViewsMetaDataProvider` gains opt-in `isQuickSavedViewEnabled` flag, plus a `userLevelRecordSecurityLock` option applicable to all saved view tables
  - Also, sharedViews becomes opt-out (by default is turned on (should this be reversed?))
- `QuerySavedViewProcess` enriches saved view results with quick view values (`type`, `sortOrder`, `doCount`) when enabled; gracefully no-ops when disabled
- Memory backend gets a feature flag (`buildJoinCrossProductFromJoinContext`) to correctly include security-required joins in cross-product construction — needed for queries involving record security locks via joins
- Comprehensive test coverage including security lock scenarios with shared views and all-access keys

## Details

### QuickSavedView entity
- Joins to SavedView via `savedViewId`, scoped per user via `userId`
- Unique constraint on `(savedViewId, userId)` prevents duplicates
- `sortOrder` controls display position; `doCount` tells frontend whether to execute count queries

### SavedViewsMetaDataProvider enhancements
- `withIsQuickSavedViewEnabled(true)` registers the QuickSavedView table and its join
- `withUserLevelRecordSecurityLock(lock)` applies record security across SavedView, SharedSavedView, and QuickSavedView tables
- SavedView security uses a multi-lock (OR) combining direct ownership and shared access via join

### MemoryRecordStore fix
- New opt-in flag to build join cross-products from `JoinsContext` (which includes security joins) rather than only explicit `QueryJoin` inputs
  - This was discovered in the test that tried to select saved views through shared saved views (which is a join added via security).  For now, just this test class opts in to the feature.
- Defaults to off for backwards compatibility; intended to become the default in a future release

## Test plan
- [x] Quick views correctly enrich saved view query results with type, sortOrder, and doCount
- [x] Process works correctly when QuickSavedView is not enabled in the instance
- [x] Applications can override `lookupQuickViews()` for custom behavior
- [x] Security locks correctly restrict access per user, with shared view and all-access scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)