### PR TITLE
feat(collapsibleElements): Initial checkin of new Collapsible meta-da…

### DIFF
--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/dashboard/QWidgetMetaData.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/dashboard/QWidgetMetaData.java
@@ -804,6 +804,7 @@ public class QWidgetMetaData implements QWidgetMetaDataInterface
     * Getter for collapsible
     * @see #withCollapsible(CollapsibleMetaData)
     *******************************************************************************/
+   @Override
    public CollapsibleMetaData getCollapsible()
    {
       return (this.collapsible);

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/dashboard/QWidgetMetaData.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/dashboard/QWidgetMetaData.java
@@ -35,6 +35,7 @@ import com.kingsrook.qqq.backend.core.model.dashboard.widgets.WidgetType;
 import com.kingsrook.qqq.backend.core.model.metadata.code.QCodeReference;
 import com.kingsrook.qqq.backend.core.model.metadata.help.HelpRole;
 import com.kingsrook.qqq.backend.core.model.metadata.help.QHelpContent;
+import com.kingsrook.qqq.backend.core.model.metadata.layout.CollapsibleMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.layout.QIcon;
 import com.kingsrook.qqq.backend.core.model.metadata.permissions.QPermissionRules;
 
@@ -72,6 +73,7 @@ public class QWidgetMetaData implements QWidgetMetaDataInterface
 
    protected QInstanceValidatorPluginInterface<QWidgetMetaDataInterface> validatorPlugin;
 
+   protected CollapsibleMetaData collapsible;
 
    /*******************************************************************************
     ** Getter for name
@@ -793,6 +795,43 @@ public class QWidgetMetaData implements QWidgetMetaDataInterface
    public QWidgetMetaData withValidatorPlugin(QInstanceValidatorPluginInterface<QWidgetMetaDataInterface> validatorPlugin)
    {
       this.validatorPlugin = validatorPlugin;
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for collapsible
+    * @see #withCollapsible(CollapsibleMetaData)
+    *******************************************************************************/
+   public CollapsibleMetaData getCollapsible()
+   {
+      return (this.collapsible);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for collapsible
+    * @see #withCollapsible(CollapsibleMetaData)
+    *******************************************************************************/
+   public void setCollapsible(CollapsibleMetaData collapsible)
+   {
+      this.collapsible = collapsible;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for collapsible
+    *
+    * @param collapsible
+    * collapsible behavior for the widget.
+    * @return this
+    *******************************************************************************/
+   public QWidgetMetaData withCollapsible(CollapsibleMetaData collapsible)
+   {
+      this.collapsible = collapsible;
       return (this);
    }
 

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/dashboard/QWidgetMetaDataInterface.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/dashboard/QWidgetMetaDataInterface.java
@@ -33,6 +33,7 @@ import com.kingsrook.qqq.backend.core.model.metadata.TopLevelMetaDataInterface;
 import com.kingsrook.qqq.backend.core.model.metadata.code.QCodeReference;
 import com.kingsrook.qqq.backend.core.model.metadata.help.HelpRole;
 import com.kingsrook.qqq.backend.core.model.metadata.help.QHelpContent;
+import com.kingsrook.qqq.backend.core.model.metadata.layout.CollapsibleMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.permissions.MetaDataWithPermissionRules;
 import com.kingsrook.qqq.backend.core.model.metadata.permissions.QPermissionRules;
 
@@ -286,5 +287,18 @@ public interface QWidgetMetaDataInterface extends MetaDataWithPermissionRules, T
    {
       return (null);
    }
+
+
+   /*******************************************************************************
+    * Getter for collapsible - specification of whether the widget should be
+    * collapsible or not, and if so, what the initial state is.
+    *
+    * @return Collapsible - null in default implementation (which means not collapsible)
+    *******************************************************************************/
+   default CollapsibleMetaData getCollapsible()
+   {
+      return (null);
+   }
+
 }
 

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/layout/CollapsibleMetaData.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/layout/CollapsibleMetaData.java
@@ -1,0 +1,102 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.metadata.layout;
+
+
+import com.kingsrook.qqq.backend.core.model.metadata.QMetaDataObject;
+
+
+/*******************************************************************************
+ * meta-data class to represent collapsible sections in a layout.
+ *
+ * <p>Used to define if an element (e.g., a table section or a widget) is
+ * collapsible, and if so, what it's default state is (opened or closed).</p>
+ *******************************************************************************/
+public class CollapsibleMetaData implements QMetaDataObject, Cloneable
+{
+   private final boolean isCollapsible;
+   private final boolean initiallyOpen;
+
+   ///////////////////////////////////////////////////////////////////////////////////////////////
+   // define the 3 commonly used states (the 4th combination (false, false) doesn't make sense) //
+   ///////////////////////////////////////////////////////////////////////////////////////////////
+   public static CollapsibleMetaData NOT_COLLAPSIBLE  = new CollapsibleMetaData(false, true);
+   public static CollapsibleMetaData INITIALLY_OPEN   = new CollapsibleMetaData(true, true);
+   public static CollapsibleMetaData INITIALLY_CLOSED = new CollapsibleMetaData(true, false);
+
+
+
+   /***************************************************************************
+    *
+    ***************************************************************************/
+   public CollapsibleMetaData(boolean isCollapsible, boolean initiallyOpen)
+   {
+      this.isCollapsible = isCollapsible;
+      this.initiallyOpen = initiallyOpen;
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for isCollapsible
+    *
+    * <p>Specifies if the element is collapsible or not.  Null should be interpreted
+    * as false (not collapsible).</p>
+    *******************************************************************************/
+   public boolean getIsCollapsible()
+   {
+      return isCollapsible;
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for initiallyOpen
+    *
+    * <p>Specifies if the element is initially open or not.  Null should be interpreted
+    * as false (not open).</p>
+    *******************************************************************************/
+   public boolean getInitiallyOpen()
+   {
+      return initiallyOpen;
+   }
+
+
+
+   /***************************************************************************
+    *
+    ***************************************************************************/
+   @Override
+   public CollapsibleMetaData clone()
+   {
+      try
+      {
+         CollapsibleMetaData clone = (CollapsibleMetaData) super.clone();
+         return clone;
+      }
+      catch(CloneNotSupportedException e)
+      {
+         throw new AssertionError();
+      }
+   }
+}
+

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/tables/QFieldSection.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/tables/QFieldSection.java
@@ -32,6 +32,7 @@ import com.kingsrook.qqq.backend.core.instances.QInstanceHelpContentManager;
 import com.kingsrook.qqq.backend.core.model.metadata.QMetaDataObject;
 import com.kingsrook.qqq.backend.core.model.metadata.help.HelpRole;
 import com.kingsrook.qqq.backend.core.model.metadata.help.QHelpContent;
+import com.kingsrook.qqq.backend.core.model.metadata.layout.CollapsibleMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.layout.QIcon;
 import com.kingsrook.qqq.backend.core.utils.collections.MutableList;
 
@@ -57,6 +58,7 @@ public class QFieldSection implements QMetaDataObject, Cloneable
 
    private Map<QFieldSectionAlternativeTypeInterface, QFieldSection> alternatives;
 
+   private CollapsibleMetaData collapsible;
 
 
    /*******************************************************************************
@@ -556,6 +558,43 @@ public class QFieldSection implements QMetaDataObject, Cloneable
       alternativeMaker.accept(alternative);
 
       this.alternatives.put(type, alternative);
+      return (this);
+   }
+
+
+
+   /*******************************************************************************
+    * Getter for collapsible
+    * @see #withCollapsible(CollapsibleMetaData)
+    *******************************************************************************/
+   public CollapsibleMetaData getCollapsible()
+   {
+      return (this.collapsible);
+   }
+
+
+
+   /*******************************************************************************
+    * Setter for collapsible
+    * @see #withCollapsible(CollapsibleMetaData)
+    *******************************************************************************/
+   public void setCollapsible(CollapsibleMetaData collapsible)
+   {
+      this.collapsible = collapsible;
+   }
+
+
+
+   /*******************************************************************************
+    * Fluent setter for collapsible
+    *
+    * @param collapsible
+    * collapsible behavior for the section.
+    * @return this
+    *******************************************************************************/
+   public QFieldSection withCollapsible(CollapsibleMetaData collapsible)
+   {
+      this.collapsible = collapsible;
       return (this);
    }
 


### PR DESCRIPTION
## Summary

Introduces a new **`CollapsibleMetaData`** class that lets metadata elements (field sections, widgets) declare whether they are collapsible and what their initial state should be (open or closed).

- New `CollapsibleMetaData` data class in the `layout` package with an `isCollapsible` flag and an `initiallyOpen` flag
- Three predefined static instances for the common cases: `NOT_COLLAPSIBLE`, `INITIALLY_OPEN`, `INITIALLY_CLOSED`
- `QFieldSection` gains a `collapsible` property (getter, setter, fluent setter) so table sections can be marked collapsible
- `QWidgetMetaData` and `QWidgetMetaDataInterface` gain the same `collapsible` property so dashboard widgets can be marked collapsible

## Details

### CollapsibleMetaData
- Immutable pair of booleans (`isCollapsible`, `initiallyOpen`) implementing `QMetaDataObject` and `Cloneable`
- Static constants cover the three meaningful combinations — the fourth (`not collapsible, not open`) is intentionally omitted

### QFieldSection
- New `collapsible` field with standard getter/setter/fluent-setter pattern, allowing sections on record view/edit screens to be independently collapsible

### QWidgetMetaData / QWidgetMetaDataInterface
- `QWidgetMetaDataInterface` adds a default `getCollapsible()` method returning `null` (not collapsible)
- `QWidgetMetaData` overrides with a concrete field and accessors, so individual widgets can opt in to collapsible behavior

## Test plan
- This is trivial java-bean code - which by convention isn't tested in this repo.
- Actual testing will happen in downstream repos, e.g., frontend-material-dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code) and 🤓[Darin Code](https://kelkhoff.com)