### PR TITLE
Feature/join enhancements

### DIFF
--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/metadata/JoinGraph.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/metadata/JoinGraph.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import com.kingsrook.qqq.backend.core.instances.QMetaDataVariableInterpreter;
@@ -34,7 +33,6 @@ import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
 import com.kingsrook.qqq.backend.core.model.metadata.joins.QJoinMetaData;
 import com.kingsrook.qqq.backend.core.utils.CollectionUtils;
 import com.kingsrook.qqq.backend.core.utils.ListingHash;
-import com.kingsrook.qqq.backend.core.utils.SortedPair;
 import com.kingsrook.qqq.backend.core.utils.StringUtils;
 
 
@@ -76,9 +74,8 @@ public class JoinGraph
    // positive could be returned if the other one (B -> A) was tested for.     //
    // so - this listing hash keeps track of all joins that are equivalent      //
    // to one another from this POV, so that any/all can be considered to match //
-   // todo - should this consider join-on fields as part of its key?           //
    //////////////////////////////////////////////////////////////////////////////
-   private ListingHash<SortedPair<String>, String> flippedJoins = new ListingHash<>();
+   private ListingHash<NormalizedJoin, String> flippedJoins = new ListingHash<>();
 
    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    // as an instance grows, with the number of joins (say, more than 50?), especially as they may have a lot of connections, //
@@ -102,81 +99,30 @@ public class JoinGraph
 
 
 
-   /*******************************************************************************
+   /***************************************************************************
     ** In this class, we are treating joins as non-directional graph edges - so -
     ** use this class to "normalize" what may otherwise be duplicated joins in the
     ** qInstance (e.g., A -> B and B -> A -- in the instance, those are valid, but
     ** in our graph here, we want to consider those the same).
-    *******************************************************************************/
-   private static class NormalizedJoin
+    ***************************************************************************/
+   private record NormalizedJoin(String tableA, String tableB, List<String> joinFieldA, List<String> joinFieldB)
    {
-      private String tableA;
-      private String tableB;
-      private String joinFieldA;
-      private String joinFieldB;
-
-
-
-      /*******************************************************************************
-       **
-       *******************************************************************************/
-      public NormalizedJoin(QJoinMetaData joinMetaData)
+      /***************************************************************************
+       *
+       ***************************************************************************/
+      static NormalizedJoin build(QJoinMetaData joinMetaData)
       {
-         boolean needFlip     = false;
-         int     tableCompare = joinMetaData.getLeftTable().compareTo(joinMetaData.getRightTable());
-         if(tableCompare < 0)
+         List<String> leftFields  = joinMetaData.getJoinOns().stream().map(jo -> jo.getLeftField()).toList();
+         List<String> rightFields = joinMetaData.getJoinOns().stream().map(jo -> jo.getRightField()).toList();
+
+         if(joinMetaData.getLeftTable().compareTo(joinMetaData.getRightTable()) < 0)
          {
-            needFlip = true;
+            return (new NormalizedJoin(joinMetaData.getLeftTable(), joinMetaData.getRightTable(), leftFields, rightFields));
          }
-         else if(tableCompare == 0)
+         else
          {
-            int fieldCompare = joinMetaData.getJoinOns().get(0).getLeftField().compareTo(joinMetaData.getJoinOns().get(0).getRightField());
-            if(fieldCompare < 0)
-            {
-               needFlip = true;
-            }
+            return (new NormalizedJoin(joinMetaData.getRightTable(), joinMetaData.getLeftTable(), rightFields, leftFields));
          }
-
-         if(needFlip)
-         {
-            joinMetaData = joinMetaData.flip();
-         }
-
-         tableA = joinMetaData.getLeftTable();
-         tableB = joinMetaData.getRightTable();
-         joinFieldA = joinMetaData.getJoinOns().get(0).getLeftField();
-         joinFieldB = joinMetaData.getJoinOns().get(0).getRightField();
-      }
-
-
-
-      /*******************************************************************************
-       **
-       *******************************************************************************/
-      @Override
-      public boolean equals(Object o)
-      {
-         if(this == o)
-         {
-            return true;
-         }
-         if(o == null || getClass() != o.getClass())
-         {
-            return false;
-         }
-         NormalizedJoin that = (NormalizedJoin) o;
-         return Objects.equals(tableA, that.tableA) && Objects.equals(tableB, that.tableB) && Objects.equals(joinFieldA, that.joinFieldA) && Objects.equals(joinFieldB, that.joinFieldB);
-      }
-
-
-
-      /*******************************************************************************
-       **
-       *******************************************************************************/
-      @Override
-      public int hashCode()
-      {
-         return Objects.hash(tableA, tableB, joinFieldA, joinFieldB);
       }
    }
 
@@ -191,9 +137,9 @@ public class JoinGraph
       Set<NormalizedJoin> usedJoins = new HashSet<>();
       for(QJoinMetaData join : CollectionUtils.nonNullMap(qInstance.getJoins()).values())
       {
-         flippedJoins.add(new SortedPair<>(join.getRightTable(), join.getLeftTable()), join.getName());
+         NormalizedJoin normalizedJoin = NormalizedJoin.build(join);
+         flippedJoins.add(NormalizedJoin.build(join), join.getName());
 
-         NormalizedJoin normalizedJoin = new NormalizedJoin(join);
          if(usedJoins.contains(normalizedJoin))
          {
             continue;
@@ -318,7 +264,7 @@ public class JoinGraph
             QJoinMetaData join = qInstance.getJoin(joinConnection.viaJoinName);
             if(join != null)
             {
-               List<String> joinNames = joinGraph.flippedJoins.get(new SortedPair<>(join.getLeftTable(), join.getRightTable()));
+               List<String> joinNames = joinGraph.flippedJoins.get(NormalizedJoin.build(join));
                for(String joinName : CollectionUtils.nonNullList(joinNames))
                {
                   if(joinName.equals(joinPath.get(i)))

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/metadata/JoinGraph.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/metadata/JoinGraph.java
@@ -316,12 +316,15 @@ public class JoinGraph
             // else consider if any flipped joins match this entry - and if so, continue //
             ///////////////////////////////////////////////////////////////////////////////
             QJoinMetaData join = qInstance.getJoin(joinConnection.viaJoinName);
-            List<String> joinNames = joinGraph.flippedJoins.get(new SortedPair<>(join.getLeftTable(), join.getRightTable()));
-            for(String joinName : joinNames)
+            if(join != null)
             {
-               if(joinName.equals(joinPath.get(i)))
+               List<String> joinNames = joinGraph.flippedJoins.get(new SortedPair<>(join.getLeftTable(), join.getRightTable()));
+               for(String joinName : CollectionUtils.nonNullList(joinNames))
                {
-                  continue OUTER;
+                  if(joinName.equals(joinPath.get(i)))
+                  {
+                     continue OUTER;
+                  }
                }
             }
 

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/metadata/JoinGraph.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/metadata/JoinGraph.java
@@ -33,16 +33,52 @@ import com.kingsrook.qqq.backend.core.instances.QMetaDataVariableInterpreter;
 import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
 import com.kingsrook.qqq.backend.core.model.metadata.joins.QJoinMetaData;
 import com.kingsrook.qqq.backend.core.utils.CollectionUtils;
+import com.kingsrook.qqq.backend.core.utils.ListingHash;
+import com.kingsrook.qqq.backend.core.utils.SortedPair;
 import com.kingsrook.qqq.backend.core.utils.StringUtils;
 
 
 /*******************************************************************************
- ** Object to represent the graph of joins in a QQQ Instance.  e.g., all of the
- ** connections among tables through joins.
+ ** Represents the graph of table-to-table joins in a QQQ Instance, treating
+ ** each join as a non-directional edge between two tables.
+ **
+ ** <p>The primary purpose of this class is to answer the question: "given a
+ ** starting table, what other tables can be reached through joins, and via
+ ** which paths?"  This is used during instance enrichment and validation to
+ ** discover multi-hop join paths (e.g., order → orderLine → item).</p>
+ **
+ ** <p>Key behaviors:</p>
+ ** <ul>
+ **    <li><b>Deduplication:</b> If the instance defines both A → B and B → A
+ **        joins (on the same fields), they are normalized into a single edge
+ **        so the graph does not contain redundant paths.</li>
+ **    <li><b>Flipped-join awareness:</b> Even though duplicate joins are
+ **        collapsed into one edge, the {@code flippedJoins} map remembers all
+ **        original join names for each table pair, so that
+ **        {@link JoinConnectionList#matchesJoinPath(List, JoinGraph, QInstance)}
+ **        can match a path by any equivalent join name, not just the one
+ **        stored in the edge.</li>
+ **    <li><b>Path-length limiting:</b> To keep traversal performant on large
+ **        instances, paths longer than {@code maxPathLength} (default 3) are
+ **        pruned.  This limit is configurable via the system property
+ **        {@code qqq.instance.joinGraph.maxPathLength} or environment variable
+ **        {@code QQQ_INSTANCE_JOIN_GRAPH_MAX_PATH_LENGTH}.</li>
+ ** </ul>
  *******************************************************************************/
 public class JoinGraph
 {
    private Set<Edge> edges = new HashSet<>();
+
+   //////////////////////////////////////////////////////////////////////////////
+   // since the joins are considered non-directional edges, if an instance has //
+   // joins A -> B, and B -> A, only one of them gets built (say, A -> B)      //
+   // But then later, in {@code JoinConnectionList.matchesJoinPath}, a false   //
+   // positive could be returned if the other one (B -> A) was tested for.     //
+   // so - this listing hash keeps track of all joins that are equivalent      //
+   // to one another from this POV, so that any/all can be considered to match //
+   // todo - should this consider join-on fields as part of its key?           //
+   //////////////////////////////////////////////////////////////////////////////
+   private ListingHash<SortedPair<String>, String> flippedJoins = new ListingHash<>();
 
    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    // as an instance grows, with the number of joins (say, more than 50?), especially as they may have a lot of connections, //
@@ -155,6 +191,8 @@ public class JoinGraph
       Set<NormalizedJoin> usedJoins = new HashSet<>();
       for(QJoinMetaData join : CollectionUtils.nonNullMap(qInstance.getJoins()).values())
       {
+         flippedJoins.add(new SortedPair<>(join.getRightTable(), join.getLeftTable()), join.getName());
+
          NormalizedJoin normalizedJoin = new NormalizedJoin(join);
          if(usedJoins.contains(normalizedJoin))
          {
@@ -244,6 +282,53 @@ public class JoinGraph
             {
                return (false);
             }
+         }
+
+         return (true);
+      }
+
+
+
+      /*******************************************************************************
+       * version of matchesJoinPath that considers flippedJoins, rather than only
+       * strictly matching the exact join names in the path.
+       *******************************************************************************/
+      public boolean matchesJoinPath(List<String> joinPath, JoinGraph joinGraph, QInstance qInstance)
+      {
+         if(list.size() != joinPath.size())
+         {
+            return (false);
+         }
+
+         OUTER:
+         for(int i = 0; i < list.size(); i++)
+         {
+            JoinConnection joinConnection = list.get(i);
+            if(joinConnection.viaJoinName().equals(joinPath.get(i)))
+            {
+               /////////////////////////////////////////////////////////////////////////
+               // if the name is an exact match, move on to the next join in the path //
+               /////////////////////////////////////////////////////////////////////////
+               continue OUTER;
+            }
+
+            ///////////////////////////////////////////////////////////////////////////////
+            // else consider if any flipped joins match this entry - and if so, continue //
+            ///////////////////////////////////////////////////////////////////////////////
+            QJoinMetaData join = qInstance.getJoin(joinConnection.viaJoinName);
+            List<String> joinNames = joinGraph.flippedJoins.get(new SortedPair<>(join.getLeftTable(), join.getRightTable()));
+            for(String joinName : joinNames)
+            {
+               if(joinName.equals(joinPath.get(i)))
+               {
+                  continue OUTER;
+               }
+            }
+
+            /////////////////////////////////////////////////////////////////
+            // if both checks above fail, then the join path doesn't match //
+            /////////////////////////////////////////////////////////////////
+            return (false);
          }
 
          return (true);

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/metadata/JoinGraph.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/metadata/JoinGraph.java
@@ -29,11 +29,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import com.kingsrook.qqq.backend.core.instances.QMetaDataVariableInterpreter;
+import com.kingsrook.qqq.backend.core.logging.QLogger;
 import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
 import com.kingsrook.qqq.backend.core.model.metadata.joins.QJoinMetaData;
 import com.kingsrook.qqq.backend.core.utils.CollectionUtils;
 import com.kingsrook.qqq.backend.core.utils.ListingHash;
 import com.kingsrook.qqq.backend.core.utils.StringUtils;
+import static com.kingsrook.qqq.backend.core.logging.LogUtils.logPair;
 
 
 /*******************************************************************************
@@ -65,6 +67,8 @@ import com.kingsrook.qqq.backend.core.utils.StringUtils;
  *******************************************************************************/
 public class JoinGraph
 {
+   private static final QLogger LOG = QLogger.getLogger(JoinGraph.class);
+
    private Set<Edge> edges = new HashSet<>();
 
    //////////////////////////////////////////////////////////////////////////////
@@ -115,7 +119,48 @@ public class JoinGraph
          List<String> leftFields  = joinMetaData.getJoinOns().stream().map(jo -> jo.getLeftField()).toList();
          List<String> rightFields = joinMetaData.getJoinOns().stream().map(jo -> jo.getRightField()).toList();
 
-         if(joinMetaData.getLeftTable().compareTo(joinMetaData.getRightTable()) < 0)
+         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+         // to normalize the join, we'll first compare table names.  if they match (a self-join), then we'll compare join fields //
+         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+         Boolean leftFirst    = null;
+         int     tableCompare = joinMetaData.getLeftTable().compareTo(joinMetaData.getRightTable());
+         if(tableCompare < 0)
+         {
+            leftFirst = true;
+         }
+         else if(tableCompare > 0)
+         {
+            leftFirst = false;
+         }
+         else
+         {
+            for(int i = 0; i < Math.min(leftFields.size(), rightFields.size()); i++)
+            {
+               int fieldCompare = leftFields.get(i).compareTo(rightFields.get(i));
+               if(fieldCompare < 0)
+               {
+                  leftFirst = true;
+                  break;
+               }
+               else if(fieldCompare > 0)
+               {
+                  leftFirst = false;
+                  break;
+               }
+            }
+         }
+
+         if(leftFirst == null)
+         {
+            ///////////////////////////////////////////////////////////////////////////////////////////////////
+            // if the sides of the joins were identical (e.g., foo.id -> foo.id), that's probably bad setup. //
+            // so warn the user about it, and choose something...                                            //
+            ///////////////////////////////////////////////////////////////////////////////////////////////////
+            LOG.warn("There appears to be a join between a table and itself, with all matching join-fields.  This could introduce unexpected behavior.", logPair("joinName", joinMetaData.getName()));
+            leftFirst = true;
+         }
+
+         if(leftFirst)
          {
             return (new NormalizedJoin(joinMetaData.getLeftTable(), joinMetaData.getRightTable(), leftFields, rightFields));
          }

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/metadata/JoinGraph.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/actions/metadata/JoinGraph.java
@@ -75,7 +75,7 @@ public class JoinGraph
    // since the joins are considered non-directional edges, if an instance has //
    // joins A -> B, and B -> A, only one of them gets built (say, A -> B)      //
    // But then later, in {@code JoinConnectionList.matchesJoinPath}, a false   //
-   // positive could be returned if the other one (B -> A) was tested for.     //
+   // negative could be returned if the other one (B -> A) was tested for.     //
    // so - this listing hash keeps track of all joins that are equivalent      //
    // to one another from this POV, so that any/all can be considered to match //
    //////////////////////////////////////////////////////////////////////////////
@@ -183,7 +183,7 @@ public class JoinGraph
       for(QJoinMetaData join : CollectionUtils.nonNullMap(qInstance.getJoins()).values())
       {
          NormalizedJoin normalizedJoin = NormalizedJoin.build(join);
-         flippedJoins.add(NormalizedJoin.build(join), join.getName());
+         flippedJoins.add(normalizedJoin, join.getName());
 
          if(usedJoins.contains(normalizedJoin))
          {
@@ -282,7 +282,9 @@ public class JoinGraph
 
       /*******************************************************************************
        * version of matchesJoinPath that considers flippedJoins, rather than only
-       * strictly matching the exact join names in the path.
+       * strictly matching the exact join names in the path (which, given the fact that
+       * the join graph may contain flipped joins, this allows for more flexible
+       * (and probably accurate for what you're looking for) matching).
        *******************************************************************************/
       public boolean matchesJoinPath(List<String> joinPath, JoinGraph joinGraph, QInstance qInstance)
       {

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/instances/QInstanceValidator.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/instances/QInstanceValidator.java
@@ -1122,7 +1122,7 @@ public class QInstanceValidator
                      boolean foundJoinConnection = false;
                      for(JoinGraph.JoinConnectionList joinConnectionList : joinConnectionsForTable)
                      {
-                        if(joinConnectionList.matchesJoinPath(exposedJoin.getJoinPath()))
+                        if(joinConnectionList.matchesJoinPath(exposedJoin.getJoinPath(), joinGraph, qInstance))
                         {
                            foundJoinConnection = true;
                         }
@@ -1130,7 +1130,7 @@ public class QInstanceValidator
                      assertCondition(foundJoinConnection, joinPrefix + "specified a joinPath [" + exposedJoin.getJoinPath() + "] which does not match a valid join connection in the instance.");
                   }
 
-                  assertCondition(!usedJoinPaths.contains(exposedJoin.getJoinPath()), tablePrefix + "has more than one join with the joinPath: " + exposedJoin.getJoinPath());
+                  assertCondition(!usedJoinPaths.contains(exposedJoin.getJoinPath()), tablePrefix + "has more than one exposed join with the joinPath: " + exposedJoin.getJoinPath());
                   usedJoinPaths.add(exposedJoin.getJoinPath());
                }
             }

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContext.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContext.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import com.kingsrook.qqq.backend.core.actions.metadata.JoinGraph;
 import com.kingsrook.qqq.backend.core.context.QContext;
 import com.kingsrook.qqq.backend.core.exceptions.QException;
 import com.kingsrook.qqq.backend.core.logging.LogPair;
@@ -56,8 +57,61 @@ import static com.kingsrook.qqq.backend.core.logging.LogUtils.logPair;
 
 
 /*******************************************************************************
- ** Helper object used throughout query (and related (count, aggregate, reporting))
- ** actions that need to track joins and aliases.
+ ** Helper object used throughout query, count, aggregate, and reporting actions
+ ** to assemble the full set of joins needed for a query, manage table aliases,
+ ** and enforce record-level security.
+ **
+ ** <p><b>Overview:</b> When a backend action (e.g., {@code RDBMSQueryAction},
+ ** {@code RDBMSCountAction}, {@code RDBMSAggregateAction}) needs to generate
+ ** SQL (or an equivalent query for other backends), it constructs a
+ ** {@code JoinsContext} from the main table name, the caller-supplied list of
+ ** {@link QueryJoin} objects, and the {@link QQueryFilter}.  During construction,
+ ** this class modifies the join list and the filter to include everything
+ ** needed for a correct, secure query.</p>
+ **
+ ** <p><b>Initialization pipeline ({@code init()}):</b></p>
+ ** <ol>
+ **   <li><b>Process existing QueryJoins</b>: validates that each join's
+ **       table exists, and populates the {@code aliasToTableNameMap} so that
+ **       later steps can resolve aliases to real table names.</li>
+ **   <li><b>{@code ensureFilterIsRepresented}</b>: scans all filter
+ **       criteria, other-field-names, and order-bys for {@code table.field}
+ **       references.  If a referenced table is not yet in the join list, a
+ **       join is added for it (with metadata resolved from the instance).</li>
+ **   <li><b>{@code ensureRecordSecurityLockIsRepresented}</b> (main table):
+ **      for each read-scope {@link RecordSecurityLock} on the main
+ **       table, ensures that any joins needed to reach the lock's security
+ **       field are present, and builds security filter criteria.</li>
+ **   <li><b>{@code fillInMissingJoinMetaData}</b>: for joins that were
+ **       added without explicit {@link QJoinMetaData} (e.g., only a table
+ **       name was specified), finds matching metadata from the
+ **       {@link QInstance}'s joins.  Also resolves indirect/multi-hop joins
+ **       via {@link ExposedJoin} paths on the main table.</li>
+ **   <li><b>{@code ensureAllJoinRecordSecurityLocksAreRepresented}</b>:
+ **       iterates over all joined tables and applies their security locks as
+ **       well, potentially adding further implicit joins.</li>
+ **   <li><b>{@code addSecurityFiltersToInputFilter}</b>: merges the
+ **       accumulated security filter into the original input filter.  If the
+ **       input filter uses {@code OR}, it is wrapped in a new {@code AND}
+ **       alongside the security filter.</li>
+ ** </ol>
+ **
+ ** <p><b>Alias management:</b> The internal {@code aliasToTableNameMap} maps
+ ** both aliases and bare table names to actual table names.  It is populated
+ ** as joins are processed.  Use {@link #resolveTableNameOrAliasToTableName}
+ ** to convert any alias/name to the real table name.</p>
+ **
+ ** <p><b>Security lock pipeline:</b> When a {@link RecordSecurityLock} has a
+ ** non-empty {@code joinNameChain}, the chain is walked (in reverse) to add
+ ** {@link ImplicitQueryJoinForSecurityLock} joins as needed.  The resulting
+ ** security criteria are placed either in the JOIN's {@code ON} clause (via
+ ** {@link QueryJoin#withSecurityCriteria}) or in the {@code WHERE} clause,
+ ** depending on whether the lock is part of an {@code OR} filter or applies
+ ** to the main table directly.</p>
+ **
+ ** <p><b>Key consumers:</b> {@code AbstractRDBMSAction} (uses this context to
+ ** build {@code FROM}, {@code WHERE}, {@code ORDER BY}, and {@code GROUP BY}
+ ** clauses), {@code MemoryRecordStore}, and {@code GenerateReportAction}.</p>
  *******************************************************************************/
 public class JoinsContext
 {
@@ -93,8 +147,13 @@ public class JoinsContext
 
 
    /*******************************************************************************
-    ** Constructor - same as original, but assumes the QInstance from QContext.
+    ** Constructor that obtains the {@link QInstance} from {@link QContext}.
     **
+    ** @param tableName  the main (root) table for the query.
+    ** @param queryJoins caller-supplied list of joins; may be empty.  Additional
+    **                   joins may be added during initialization.
+    ** @param filter     the query filter; may be mutated to include security criteria.
+    ** @throws QException if a referenced table or join cannot be resolved.
     *******************************************************************************/
    public JoinsContext(String tableName, List<QueryJoin> queryJoins, QQueryFilter filter) throws QException
    {
@@ -104,8 +163,14 @@ public class JoinsContext
 
 
    /*******************************************************************************
-    * Constructor - original.
-    *
+    ** Primary constructor.
+    **
+    ** @param instance   the QInstance containing table and join metadata.
+    ** @param tableName  the main (root) table for the query.
+    ** @param queryJoins caller-supplied list of joins; may be empty.  Additional
+    **                   joins may be added during initialization.
+    ** @param filter     the query filter; may be mutated to include security criteria.
+    ** @throws QException if a referenced table or join cannot be resolved.
     *******************************************************************************/
    public JoinsContext(QInstance instance, String tableName, List<QueryJoin> queryJoins, QQueryFilter filter) throws QException
    {
@@ -121,9 +186,16 @@ public class JoinsContext
 
 
    /*******************************************************************************
-    * Constructor - allows you to omit security, and doesn't pre-assume any
-    * query joins.
-    *
+    ** Constructor that starts with an empty join list and optionally skips
+    ** security-lock processing.  Obtains the {@link QInstance} from {@link QContext}.
+    **
+    ** @param tableName    the main (root) table for the query.
+    ** @param filter       the query filter; may be mutated to include security criteria
+    **                     (unless {@code omitSecurity} is {@code true}).
+    ** @param omitSecurity if {@code true}, the initialization pipeline will not
+    **                     process any {@link RecordSecurityLock}s or add security
+    **                     filters.
+    ** @throws QException if a referenced table or join cannot be resolved.
     *******************************************************************************/
    public JoinsContext(String tableName, QQueryFilter filter, boolean omitSecurity) throws QException
    {
@@ -807,20 +879,23 @@ public class JoinsContext
                   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
                   QTableMetaData mainTable          = instance.getTable(mainTableName);
                   boolean        addedAnyQueryJoins = false;
-                  for(ExposedJoin exposedJoin : CollectionUtils.nonNullList(mainTable.getExposedJoins()))
+                  boolean        foundJoinMetaData  = false;
+
+                  List<JoinTableAndPath> joinTablesAndPaths = getJoinTablesAndPaths(mainTable, true);
+                  for(JoinTableAndPath joinTableAndPath : joinTablesAndPaths)
                   {
-                     if(queryJoin.getJoinTable().equals(exposedJoin.getJoinTable()))
+                     if(queryJoin.getJoinTable().equals(joinTableAndPath.joinTable()))
                      {
-                        log("- - Found an exposed join", logPair("mainTable", mainTableName), logPair("joinTable", queryJoin.getJoinTable()), logPair("joinPath", exposedJoin.getJoinPath()));
+                        log("- - Found an exposed join", logPair("mainTable", mainTableName), logPair("joinTable", queryJoin.getJoinTable()), logPair("joinPath", joinTableAndPath.joinPath()));
 
                         /////////////////////////////////////////////////////////////////////////////////////
                         // loop backward through the join path (from the joinTable back to the main table) //
                         // adding joins to the table (if they aren't already in the query)                 //
                         /////////////////////////////////////////////////////////////////////////////////////
                         String tmpTable = queryJoin.getJoinTable();
-                        for(int i = exposedJoin.getJoinPath().size() - 1; i >= 0; i--)
+                        for(int i = joinTableAndPath.joinPath().size() - 1; i >= 0; i--)
                         {
-                           String        joinName  = exposedJoin.getJoinPath().get(i);
+                           String joinName = joinTableAndPath.joinPath().get(i);
                            QJoinMetaData joinToAdd = instance.getJoin(joinName);
                            log("- - - evaluating joinPath element", logPair("i", i), logPair("joinName", joinName));
 
@@ -844,7 +919,7 @@ public class JoinsContext
                               // if this is the last element in the joinPath, then we want to set this joinMetaData on the outer queryJoin //
                               // - else, we need to add a new queryJoin to this context                                                    //
                               ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
-                              if(i == exposedJoin.getJoinPath().size() - 1)
+                              if(i == joinTableAndPath.joinPath().size() - 1)
                               {
                                  if(queryJoin.getBaseTableOrAlias() == null)
                                  {
@@ -870,7 +945,19 @@ public class JoinsContext
 
                            tmpTable = nextTable;
                         }
+
+                        ////////////////////////////////////////////////////////////////
+                        // break the loop over exposed joins - and mark that we found //
+                        // join meta data for this query join that was missing it.    //
+                        ////////////////////////////////////////////////////////////////
+                        foundJoinMetaData = true;
+                        break;
                      }
+                  }
+
+                  if(!foundJoinMetaData)
+                  {
+                     LOG.warn("Unable to find joinMetaData for queryJoin", logPair("mainTable", mainTable), logPair("queryJoin", queryJoin));
                   }
 
                   ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -936,8 +1023,11 @@ public class JoinsContext
 
 
    /*******************************************************************************
-    ** Getter for queryJoins
+    ** Returns the live list of {@link QueryJoin} objects in this context.  This
+    ** includes both caller-supplied joins and any that were added automatically
+    ** (for filters, security locks, or exposed-join paths).
     **
+    ** @return the mutable list of query joins.
     *******************************************************************************/
    public List<QueryJoin> getQueryJoins()
    {
@@ -947,8 +1037,12 @@ public class JoinsContext
 
 
    /*******************************************************************************
-    ** For a given name (whether that's a table name or an alias in the query),
-    ** get the actual table name (e.g., that could be passed to qInstance.getTable())
+    ** Resolves a name (which may be an alias or an actual table name) to the
+    ** real table name that can be passed to {@code qInstance.getTable()}.
+    ** If the name is not found in the alias map, it is returned as-is.
+    **
+    ** @param nameOrAlias  an alias or table name present in this context.
+    ** @return the actual table name.
     *******************************************************************************/
    public String resolveTableNameOrAliasToTableName(String nameOrAlias)
    {
@@ -962,8 +1056,19 @@ public class JoinsContext
 
 
    /*******************************************************************************
-    ** For a given fieldName, which we expect may start with a tableNameOrAlias + '.',
-    ** find the QFieldMetaData and the tableNameOrAlias that it corresponds to.
+    ** Parses a field reference (optionally prefixed with {@code tableOrAlias.})
+    ** and returns the resolved {@link QFieldMetaData} together with the table
+    ** name or alias it belongs to.
+    **
+    ** <p>If {@code fieldName} contains a dot (e.g., {@code "department.name"}),
+    ** the part before the dot is treated as a table name or alias and resolved
+    ** via the alias map.  If there is no dot, the field is looked up on the main
+    ** table.</p>
+    **
+    ** @param fieldName  a field name, optionally qualified as {@code table.field}.
+    ** @return a {@link FieldAndTableNameOrAlias} record.
+    ** @throws IllegalArgumentException if the name has more than one dot, or the
+    **         table/field cannot be found.
     *******************************************************************************/
    public FieldAndTableNameOrAlias getFieldAndTableNameOrAlias(String fieldName)
    {
@@ -1134,7 +1239,23 @@ public class JoinsContext
 
 
    /*******************************************************************************
+    ** Searches the {@link QInstance}'s joins for a {@link QJoinMetaData} that
+    ** connects {@code baseTableName} to {@code joinTableName} (checking both
+    ** directions and flipping if needed).
     **
+    ** <p>If multiple matches are found and {@code useExposedJoins} is
+    ** {@code true}, the main table's {@link ExposedJoin} list is consulted to
+    ** disambiguate.  If disambiguation fails, a {@link RuntimeException} is
+    ** thrown.</p>
+    **
+    ** @param baseTableName   the "left" / base table (may be {@code null} to
+    **                        match any table already in this context).
+    ** @param joinTableName   the "right" / target table.
+    ** @param useExposedJoins whether to use exposed joins for disambiguation
+    **                        when multiple matches are found.
+    ** @return the matching {@link QJoinMetaData}, or {@code null} if none found.
+    ** @throws RuntimeException if more than one join matches and disambiguation
+    **         fails.
     *******************************************************************************/
    public QJoinMetaData findJoinMetaData(String baseTableName, String joinTableName, boolean useExposedJoins)
    {
@@ -1219,7 +1340,12 @@ public class JoinsContext
 
 
    /*******************************************************************************
+    ** Record pairing a resolved {@link QFieldMetaData} with the table name or
+    ** alias from which it was resolved.
     **
+    ** @param field            the field's metadata.
+    ** @param tableNameOrAlias the table name or alias that the field belongs to,
+    **                         as it should appear in generated SQL.
     *******************************************************************************/
    public record FieldAndTableNameOrAlias(QFieldMetaData field, String tableNameOrAlias)
    {
@@ -1310,5 +1436,56 @@ public class JoinsContext
       {
          System.out.println(StringUtils.safeTruncate("-".repeat(full), full));
       }
+   }
+
+
+
+   /***************************************************************************
+    * For a given table, get a list of tables that can be joined to it, along
+    * with a path of joins that go from the input table to the join table.
+    *
+    * Per the @{code onlyExposedJoins} parameter, this method will only consider
+    * exposed joins on the table, or it may also include all joins that are
+    * available in the instance, based on the join graph.
+    *
+    * @param table the table to get joins for.
+    * @param onlyExposedJoins whether to only consider exposed joins.
+    * @return a list of joins that can be used to join to the given table.
+    ***************************************************************************/
+   private List<JoinTableAndPath> getJoinTablesAndPaths(QTableMetaData table, boolean onlyExposedJoins)
+   {
+      List<JoinTableAndPath> rs = new ArrayList<>();
+
+      for(ExposedJoin exposedJoin : CollectionUtils.nonNullList(table.getExposedJoins()))
+      {
+         rs.add(new JoinTableAndPath(exposedJoin.getJoinTable(), exposedJoin.getJoinPath()));
+      }
+
+      if(!onlyExposedJoins)
+      {
+         JoinGraph                         joinGraph       = QContext.getQInstance().getJoinGraph();
+         Set<JoinGraph.JoinConnectionList> joinConnections = joinGraph.getJoinConnections(table.getName());
+         for(JoinGraph.JoinConnectionList joinConnection : joinConnections)
+         {
+            List<String>  joinNamesAsList = joinConnection.getJoinNamesAsList();
+            String        lastJoinName    = joinNamesAsList.getLast();
+            QJoinMetaData lastJoin        = QContext.getQInstance().getJoin(lastJoinName);
+
+            rs.add(new JoinTableAndPath(lastJoin.getLeftTable(), joinNamesAsList));
+            rs.add(new JoinTableAndPath(lastJoin.getRightTable(), joinNamesAsList));
+         }
+      }
+
+      return (rs);
+   }
+
+
+
+   /***************************************************************************
+    * helper record that connects a joinTable to a path of join names that
+    * get from a source table to that joinTable.
+    ***************************************************************************/
+   private record JoinTableAndPath(String joinTable, List<String> joinPath)
+   {
    }
 }

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/utils/SortedPair.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/utils/SortedPair.java
@@ -1,0 +1,40 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.utils;
+
+
+/*******************************************************************************
+ **
+ *******************************************************************************/
+public class SortedPair<A extends Comparable<A>> extends Pair<A, A>
+{
+
+   /*******************************************************************************
+    ** Constructor
+    **
+    *******************************************************************************/
+   public SortedPair(A a, A b)
+   {
+      super(a.compareTo(b) <= 0 ? a : b, a.compareTo(b) <= 0 ? b : a);
+   }
+
+}

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/utils/SortedPair.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/utils/SortedPair.java
@@ -34,7 +34,31 @@ public class SortedPair<A extends Comparable<A>> extends Pair<A, A>
     *******************************************************************************/
    public SortedPair(A a, A b)
    {
-      super(a.compareTo(b) <= 0 ? a : b, a.compareTo(b) <= 0 ? b : a);
+      super(compare(a, b) <= 0 ? a : b, compare(a, b) <= 0 ? b : a);
+   }
+
+
+   /***************************************************************************
+    * do a null-safe compare that the constructor can use.
+    ***************************************************************************/
+   private static <A extends Comparable<A>> int compare(A a, A b)
+   {
+      if(a == null && b == null)
+      {
+         return (0);
+      }
+      else if(a == null)
+      {
+         return (-1);
+      }
+      else if(b == null)
+      {
+         return (1);
+      }
+      else
+      {
+         return (a.compareTo(b));
+      }
    }
 
 }

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/actions/metadata/JoinGraphTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/actions/metadata/JoinGraphTest.java
@@ -197,6 +197,72 @@ class JoinGraphTest extends BaseTest
 
 
    /*******************************************************************************
+    ** Test that joins between the same table pair are NOT deduplicated when their
+    ** join-on fields are different.
+    *******************************************************************************/
+   @Test
+   void testJoinsWithDifferentJoinOnsAreNotDeduplicated()
+   {
+      QInstance qInstance = new QInstance();
+
+      qInstance.addJoin(new QJoinMetaData()
+         .withName("orderToOrderLineByOrderId")
+         .withLeftTable("order")
+         .withRightTable("orderLine")
+         .withType(JoinType.ONE_TO_MANY)
+         .withJoinOn(new JoinOn("id", "orderId")));
+
+      qInstance.addJoin(new QJoinMetaData()
+         .withName("orderToOrderLineByStoreId")
+         .withLeftTable("order")
+         .withRightTable("orderLine")
+         .withType(JoinType.ONE_TO_MANY)
+         .withJoinOn(new JoinOn("storeId", "storeId")));
+
+      JoinGraph joinGraph = new JoinGraph(qInstance);
+
+      Set<JoinGraph.JoinConnectionList> fromOrder = joinGraph.getJoinConnections("order");
+
+      List<JoinGraph.JoinConnectionList> oneHopToOrderLine = fromOrder.stream()
+         .filter(jcl -> jcl.list().size() == 1 && jcl.list().get(0).joinTable().equals("orderLine"))
+         .toList();
+
+      assertEquals(2, oneHopToOrderLine.size());
+      assertTrue(oneHopToOrderLine.stream().anyMatch(jcl -> jcl.list().get(0).viaJoinName().equals("orderToOrderLineByOrderId")));
+      assertTrue(oneHopToOrderLine.stream().anyMatch(jcl -> jcl.list().get(0).viaJoinName().equals("orderToOrderLineByStoreId")));
+   }
+
+
+
+
+   /*******************************************************************************
+    * test an odd-ball case (probably not supported, nor intended/correct) where
+    * a join breaks the sorting rules (between left & right) in NormalizedJoin.build,
+    * because it has the same table name on bot sides, and the same list of join
+    * fields on both sides (e.g., employee.id -> employee.id).
+    *******************************************************************************/
+   @Test
+   void testIdenticalJoins()
+   {
+      QInstance qInstance = new QInstance();
+
+      qInstance.addJoin(new QJoinMetaData()
+         .withName("employeeToSelf")
+         .withLeftTable("employee")
+         .withRightTable("employee")
+         .withType(JoinType.MANY_TO_ONE)
+         .withJoinOn(new JoinOn("id", "id")));
+
+      new JoinGraph(qInstance);
+
+      ///////////////////////////////////////////////////////////////////////////////////////////////
+      // just make sure we didn't crash (or infinitely loop or some-such) on this unsupported case //
+      ///////////////////////////////////////////////////////////////////////////////////////////////
+   }
+
+
+
+   /*******************************************************************************
     **
     *******************************************************************************/
    @Test
@@ -312,6 +378,48 @@ class JoinGraphTest extends BaseTest
       // a completely unrelated join name should not match either way //
       //////////////////////////////////////////////////////////////////
       assertFalse(connectionList.matchesJoinPath(List.of("bogusJoin"), joinGraph, qInstance));
+   }
+
+
+
+   /*******************************************************************************
+    ** For a self-join, verify flipped definitions normalize to the same key so
+    ** flippedJoins-aware matching treats both names as equivalent.
+    *******************************************************************************/
+   @Test
+   void testMatchesJoinPathWithFlippedSelfJoin()
+   {
+      QInstance qInstance = new QInstance();
+
+      qInstance.addJoin(new QJoinMetaData()
+         .withName("employeeToManager")
+         .withLeftTable("employee")
+         .withRightTable("employee")
+         .withType(JoinType.MANY_TO_ONE)
+         .withJoinOn(new JoinOn("managerId", "id")));
+
+      qInstance.addJoin(new QJoinMetaData()
+         .withName("managerToEmployee")
+         .withLeftTable("employee")
+         .withRightTable("employee")
+         .withType(JoinType.ONE_TO_MANY)
+         .withJoinOn(new JoinOn("id", "managerId")));
+
+      JoinGraph joinGraph = new JoinGraph(qInstance);
+
+      JoinGraph.JoinConnectionList connectionList = new JoinGraph.JoinConnectionList(List.of(
+         new JoinGraph.JoinConnection("employee", "employeeToManager")));
+
+      ///////////////////////////////////////////////////////////////////////////////////////////////
+      // the overload of matchesJoinPath that only takes string won't see the 2nd join as matching //
+      ///////////////////////////////////////////////////////////////////////////////////////////////
+      assertTrue(connectionList.matchesJoinPath(List.of("employeeToManager")));
+      assertFalse(connectionList.matchesJoinPath(List.of("managerToEmployee")));
+      ///////////////////////////////////////////////////////////////////////////////////////////////////////
+      // but the overload that takes the graph - it can see flipped joins, so it will see both as matching //
+      ///////////////////////////////////////////////////////////////////////////////////////////////////////
+      assertTrue(connectionList.matchesJoinPath(List.of("employeeToManager"), joinGraph, qInstance));
+      assertTrue(connectionList.matchesJoinPath(List.of("managerToEmployee"), joinGraph, qInstance));
    }
 
 

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/actions/metadata/JoinGraphTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/actions/metadata/JoinGraphTest.java
@@ -1,0 +1,467 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2025.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.actions.metadata;
+
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import com.kingsrook.qqq.backend.core.BaseTest;
+import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
+import com.kingsrook.qqq.backend.core.model.metadata.joins.JoinOn;
+import com.kingsrook.qqq.backend.core.model.metadata.joins.JoinType;
+import com.kingsrook.qqq.backend.core.model.metadata.joins.QJoinMetaData;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/*******************************************************************************
+ ** Unit test for JoinGraph
+ *******************************************************************************/
+class JoinGraphTest extends BaseTest
+{
+
+   /*******************************************************************************
+    ** Build a simple instance with 3 tables in a chain: order -> orderLine -> item
+    *******************************************************************************/
+   private QInstance buildSimpleInstance()
+   {
+      QInstance qInstance = new QInstance();
+
+      qInstance.addJoin(new QJoinMetaData()
+         .withName("orderToOrderLine")
+         .withLeftTable("order")
+         .withRightTable("orderLine")
+         .withType(JoinType.ONE_TO_MANY)
+         .withJoinOn(new JoinOn("id", "orderId")));
+
+      qInstance.addJoin(new QJoinMetaData()
+         .withName("orderLineToItem")
+         .withLeftTable("orderLine")
+         .withRightTable("item")
+         .withType(JoinType.MANY_TO_ONE)
+         .withJoinOn(new JoinOn("itemId", "id")));
+
+      return qInstance;
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testGetJoinConnectionsSimpleChain()
+   {
+      QInstance  qInstance = buildSimpleInstance();
+      JoinGraph  joinGraph = new JoinGraph(qInstance);
+
+      ///////////////////////////////////////////////////////
+      // from "order" we should reach orderLine (directly) //
+      // and item (via orderLine)                          //
+      ///////////////////////////////////////////////////////
+      Set<JoinGraph.JoinConnectionList> connections = joinGraph.getJoinConnections("order");
+      assertEquals(2, connections.size());
+
+      /////////////////////////////////////
+      // verify direct join to orderLine //
+      /////////////////////////////////////
+      Optional<JoinGraph.JoinConnectionList> directToOrderLine = connections.stream()
+         .filter(jcl -> jcl.list().size() == 1 && jcl.list().get(0).joinTable().equals("orderLine"))
+         .findFirst();
+      assertTrue(directToOrderLine.isPresent());
+      assertEquals("orderToOrderLine", directToOrderLine.get().list().get(0).viaJoinName());
+
+      ///////////////////////////////
+      // verify 2-hop join to item //
+      ///////////////////////////////
+      Optional<JoinGraph.JoinConnectionList> toItem = connections.stream()
+         .filter(jcl -> jcl.list().size() == 2)
+         .findFirst();
+      assertTrue(toItem.isPresent());
+      assertEquals("orderLine", toItem.get().list().get(0).joinTable());
+      assertEquals("item", toItem.get().list().get(1).joinTable());
+      assertEquals("orderLineToItem", toItem.get().list().get(1).viaJoinName());
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testGetJoinConnectionsFromMiddleTable()
+   {
+      QInstance  qInstance = buildSimpleInstance();
+      JoinGraph  joinGraph = new JoinGraph(qInstance);
+
+      //////////////////////////////////////////////////////////////////
+      // from "orderLine" we should reach order and item (1 hop each) //
+      //////////////////////////////////////////////////////////////////
+      Set<JoinGraph.JoinConnectionList> connections = joinGraph.getJoinConnections("orderLine");
+      assertEquals(2, connections.size());
+
+      assertTrue(connections.stream().anyMatch(jcl ->
+         jcl.list().size() == 1
+            && jcl.list().get(0).joinTable().equals("order")
+            && jcl.list().get(0).viaJoinName().equals("orderToOrderLine")));
+
+      assertTrue(connections.stream().anyMatch(jcl ->
+         jcl.list().size() == 1
+            && jcl.list().get(0).joinTable().equals("item")
+            && jcl.list().get(0).viaJoinName().equals("orderLineToItem")));
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testGetJoinConnectionsNoConnections()
+   {
+      QInstance qInstance = new QInstance();
+      qInstance.addJoin(new QJoinMetaData()
+         .withName("aToB")
+         .withLeftTable("a")
+         .withRightTable("b")
+         .withType(JoinType.ONE_TO_ONE)
+         .withJoinOn(new JoinOn("bId", "id")));
+
+      JoinGraph joinGraph = new JoinGraph(qInstance);
+
+      ///////////////////////////////////////////////////////////
+      // a table not involved in any join should have no paths //
+      ///////////////////////////////////////////////////////////
+      Set<JoinGraph.JoinConnectionList> connections = joinGraph.getJoinConnections("unrelated");
+      assertTrue(connections.isEmpty());
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that duplicate (flipped) joins between the same tables are deduplicated
+    ** in the graph edges - i.e., if we have A->B and B->A, the graph still only
+    ** has one edge between them.
+    *******************************************************************************/
+   @Test
+   void testDuplicateJoinsAreDeduplicated()
+   {
+      QInstance qInstance = new QInstance();
+
+      qInstance.addJoin(new QJoinMetaData()
+         .withName("orderToOrderLine")
+         .withLeftTable("order")
+         .withRightTable("orderLine")
+         .withType(JoinType.ONE_TO_MANY)
+         .withJoinOn(new JoinOn("id", "orderId")));
+
+      qInstance.addJoin(new QJoinMetaData()
+         .withName("orderLineToOrder")
+         .withLeftTable("orderLine")
+         .withRightTable("order")
+         .withType(JoinType.MANY_TO_ONE)
+         .withJoinOn(new JoinOn("orderId", "id")));
+
+      JoinGraph joinGraph = new JoinGraph(qInstance);
+
+      ////////////////////////////////////////////////////////////////////////////
+      // even with two joins defined between the same pair, there's only 1 path //
+      ////////////////////////////////////////////////////////////////////////////
+      Set<JoinGraph.JoinConnectionList> fromOrder = joinGraph.getJoinConnections("order");
+      assertEquals(1, fromOrder.size());
+      assertEquals("orderLine", fromOrder.iterator().next().list().get(0).joinTable());
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testMatchesJoinPathSimple()
+   {
+      QInstance  qInstance = buildSimpleInstance();
+      JoinGraph  joinGraph = new JoinGraph(qInstance);
+
+      Set<JoinGraph.JoinConnectionList> connections = joinGraph.getJoinConnections("order");
+
+      /////////////////////////////////////////////////////////////////
+      // find the 1-hop path to orderLine and verify matchesJoinPath //
+      /////////////////////////////////////////////////////////////////
+      JoinGraph.JoinConnectionList directPath = connections.stream()
+         .filter(jcl -> jcl.list().size() == 1)
+         .findFirst()
+         .orElseThrow();
+
+      assertTrue(directPath.matchesJoinPath(List.of("orderToOrderLine")));
+      assertFalse(directPath.matchesJoinPath(List.of("orderLineToItem")));
+      assertFalse(directPath.matchesJoinPath(List.of("orderToOrderLine", "orderLineToItem")));
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testMatchesJoinPathMultiHop()
+   {
+      QInstance  qInstance = buildSimpleInstance();
+      JoinGraph  joinGraph = new JoinGraph(qInstance);
+
+      Set<JoinGraph.JoinConnectionList> connections = joinGraph.getJoinConnections("order");
+
+      ////////////////////////////////////////////////////////////
+      // find the 2-hop path to item and verify matchesJoinPath //
+      ////////////////////////////////////////////////////////////
+      JoinGraph.JoinConnectionList twoHopPath = connections.stream()
+         .filter(jcl -> jcl.list().size() == 2)
+         .findFirst()
+         .orElseThrow();
+
+      assertTrue(twoHopPath.matchesJoinPath(List.of("orderToOrderLine", "orderLineToItem")));
+      assertFalse(twoHopPath.matchesJoinPath(List.of("orderLineToItem", "orderToOrderLine")));
+      assertFalse(twoHopPath.matchesJoinPath(List.of("orderToOrderLine")));
+   }
+
+
+
+   /*******************************************************************************
+    ** This test exercises the flippedJoins-aware matchesJoinPath overload.
+    ** Scenario: the instance has two joins between order and orderLine:
+    ** - orderToOrderLine (order -> orderLine)
+    ** - orderLineToOrder (orderLine -> order)
+    ** The graph deduplicates them into one edge (using orderToOrderLine).
+    ** When we ask matchesJoinPath for "orderLineToOrder", it should still match
+    ** because the flippedJoins map knows they're equivalent.
+    ** This exercises line 300 (continue OUTER via flippedJoins match).
+    *******************************************************************************/
+   @Test
+   void testMatchesJoinPathWithFlippedJoins()
+   {
+      QInstance qInstance = new QInstance();
+
+      qInstance.addJoin(new QJoinMetaData()
+         .withName("orderToOrderLine")
+         .withLeftTable("order")
+         .withRightTable("orderLine")
+         .withType(JoinType.ONE_TO_MANY)
+         .withJoinOn(new JoinOn("id", "orderId")));
+
+      qInstance.addJoin(new QJoinMetaData()
+         .withName("orderLineToOrder")
+         .withLeftTable("orderLine")
+         .withRightTable("order")
+         .withType(JoinType.MANY_TO_ONE)
+         .withJoinOn(new JoinOn("orderId", "id")));
+
+      JoinGraph joinGraph = new JoinGraph(qInstance);
+
+      Set<JoinGraph.JoinConnectionList> connections = joinGraph.getJoinConnections("order");
+      assertEquals(1, connections.size());
+
+      JoinGraph.JoinConnectionList connectionList = connections.iterator().next();
+
+      /////////////////////////////////////////////////////////////////
+      // the edge stored uses "orderToOrderLine" as the join name    //
+      // so a simple matchesJoinPath with the exact name should work //
+      /////////////////////////////////////////////////////////////////
+      assertTrue(connectionList.matchesJoinPath(List.of("orderToOrderLine")));
+
+      //////////////////////////////////////////////////////////////////////
+      // a simple matchesJoinPath (no flipped joins) should NOT match the //
+      // alternate name, because it only does exact name comparison       //
+      //////////////////////////////////////////////////////////////////////
+      assertFalse(connectionList.matchesJoinPath(List.of("orderLineToOrder")));
+
+      /////////////////////////////////////////////////////////////////////////
+      // but the flippedJoins-aware overload SHOULD match "orderLineToOrder" //
+      // because it knows both join names refer to the same table pair.      //
+      // This is the code path that hits line 300 (continue OUTER).          //
+      /////////////////////////////////////////////////////////////////////////
+      assertTrue(connectionList.matchesJoinPath(List.of("orderLineToOrder"), joinGraph, qInstance));
+
+      ////////////////////////////////////////////////////////////////////
+      // and the exact name should also still work via the 3-arg method //
+      ////////////////////////////////////////////////////////////////////
+      assertTrue(connectionList.matchesJoinPath(List.of("orderToOrderLine"), joinGraph, qInstance));
+
+      //////////////////////////////////////////////////////////////////
+      // a completely unrelated join name should not match either way //
+      //////////////////////////////////////////////////////////////////
+      assertFalse(connectionList.matchesJoinPath(List.of("bogusJoin"), joinGraph, qInstance));
+   }
+
+
+
+   /*******************************************************************************
+    ** Test the flipped-joins-aware matchesJoinPath for a multi-hop path where
+    ** one of the hops uses the alternate (flipped) join name.
+    *******************************************************************************/
+   @Test
+   void testMatchesJoinPathWithFlippedJoinsMultiHop()
+   {
+      QInstance qInstance = new QInstance();
+
+      qInstance.addJoin(new QJoinMetaData()
+         .withName("orderToOrderLine")
+         .withLeftTable("order")
+         .withRightTable("orderLine")
+         .withType(JoinType.ONE_TO_MANY)
+         .withJoinOn(new JoinOn("id", "orderId")));
+
+      qInstance.addJoin(new QJoinMetaData()
+         .withName("orderLineToOrder")
+         .withLeftTable("orderLine")
+         .withRightTable("order")
+         .withType(JoinType.MANY_TO_ONE)
+         .withJoinOn(new JoinOn("orderId", "id")));
+
+      qInstance.addJoin(new QJoinMetaData()
+         .withName("orderLineToItem")
+         .withLeftTable("orderLine")
+         .withRightTable("item")
+         .withType(JoinType.MANY_TO_ONE)
+         .withJoinOn(new JoinOn("itemId", "id")));
+
+      JoinGraph joinGraph = new JoinGraph(qInstance);
+
+      //////////////////////////////////////////////////////////////////
+      // from "order", get the 2-hop path: order -> orderLine -> item //
+      //////////////////////////////////////////////////////////////////
+      Set<JoinGraph.JoinConnectionList> connections = joinGraph.getJoinConnections("order");
+      JoinGraph.JoinConnectionList twoHopPath = connections.stream()
+         .filter(jcl -> jcl.list().size() == 2 && jcl.list().get(1).joinTable().equals("item"))
+         .findFirst()
+         .orElseThrow();
+
+      ////////////////////////////////////////////////////////////////////////////////////
+      // the stored path uses "orderToOrderLine" for the first hop.                     //
+      // asking with "orderLineToOrder" as the first hop should match via flippedJoins. //
+      ////////////////////////////////////////////////////////////////////////////////////
+      assertTrue(twoHopPath.matchesJoinPath(List.of("orderLineToOrder", "orderLineToItem"), joinGraph, qInstance));
+      assertTrue(twoHopPath.matchesJoinPath(List.of("orderToOrderLine", "orderLineToItem"), joinGraph, qInstance));
+
+      ////////////////////////////
+      // wrong size should fail //
+      ////////////////////////////
+      assertFalse(twoHopPath.matchesJoinPath(List.of("orderLineToOrder"), joinGraph, qInstance));
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testJoinConnectionListCompareTo()
+   {
+      JoinGraph.JoinConnectionList list1 = new JoinGraph.JoinConnectionList(List.of(
+         new JoinGraph.JoinConnection("alpha", "joinA")));
+
+      JoinGraph.JoinConnectionList list2 = new JoinGraph.JoinConnectionList(List.of(
+         new JoinGraph.JoinConnection("beta", "joinB")));
+
+      JoinGraph.JoinConnectionList list1Copy = new JoinGraph.JoinConnectionList(List.of(
+         new JoinGraph.JoinConnection("alpha", "joinA")));
+
+      assertEquals(0, list1.compareTo(list1Copy));
+      assertTrue(list1.compareTo(list2) < 0);
+      assertTrue(list2.compareTo(list1) > 0);
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testJoinConnectionListCompareToBySize()
+   {
+      JoinGraph.JoinConnectionList shorter = new JoinGraph.JoinConnectionList(List.of(
+         new JoinGraph.JoinConnection("alpha", "joinA")));
+
+      JoinGraph.JoinConnectionList longer = new JoinGraph.JoinConnectionList(List.of(
+         new JoinGraph.JoinConnection("alpha", "joinA"),
+         new JoinGraph.JoinConnection("beta", "joinB")));
+
+      assertTrue(shorter.compareTo(longer) < 0);
+      assertTrue(longer.compareTo(shorter) > 0);
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testJoinConnectionListGetJoinNames()
+   {
+      JoinGraph.JoinConnectionList connectionList = new JoinGraph.JoinConnectionList(List.of(
+         new JoinGraph.JoinConnection("orderLine", "orderToOrderLine"),
+         new JoinGraph.JoinConnection("item", "orderLineToItem")));
+
+      assertEquals("orderToOrderLine, orderLineToItem", connectionList.getJoinNamesAsString());
+      assertEquals(List.of("orderToOrderLine", "orderLineToItem"), connectionList.getJoinNamesAsList());
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testJoinConnectionListCopy()
+   {
+      JoinGraph.JoinConnectionList original = new JoinGraph.JoinConnectionList(new java.util.ArrayList<>(List.of(
+         new JoinGraph.JoinConnection("orderLine", "orderToOrderLine"))));
+
+      JoinGraph.JoinConnectionList copy = original.copy();
+      assertEquals(original, copy);
+
+      ///////////////////////////////////////////////////
+      // modifying the copy should not affect original //
+      ///////////////////////////////////////////////////
+      copy.list().add(new JoinGraph.JoinConnection("item", "orderLineToItem"));
+      assertEquals(1, original.list().size());
+      assertEquals(2, copy.list().size());
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void testEmptyInstance()
+   {
+      QInstance qInstance = new QInstance();
+      JoinGraph joinGraph = new JoinGraph(qInstance);
+
+      Set<JoinGraph.JoinConnectionList> connections = joinGraph.getJoinConnections("anyTable");
+      assertTrue(connections.isEmpty());
+   }
+
+}

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/instances/QInstanceValidatorTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/instances/QInstanceValidatorTest.java
@@ -2432,13 +2432,30 @@ public class QInstanceValidatorTest extends BaseTest
          qInstance.addTable(newTable("B", "id", "aId"));
          qInstance.addJoin(new QJoinMetaData().withLeftTable("A").withRightTable("B").withName("AB").withType(JoinType.ONE_TO_ONE).withJoinOn(new JoinOn("id", "aId")));
       },
-         "than one join with the joinPath: [AB]");
+         "than one exposed join with the joinPath: [AB]");
 
       assertValidationSuccess(qInstance ->
       {
          qInstance.addTable(newTable("A", "id").withExposedJoin(new ExposedJoin().withJoinTable("B").withLabel("B").withJoinPath(List.of("AB"))));
          qInstance.addTable(newTable("B", "id", "aId"));
          qInstance.addJoin(new QJoinMetaData().withLeftTable("A").withRightTable("B").withName("AB").withType(JoinType.ONE_TO_ONE).withJoinOn(new JoinOn("id", "aId")));
+      });
+
+      assertValidationSuccess(qInstance ->
+      {
+         ///////////////////////////////////////////////////////////////////////////////////////////////
+         // this case helps verify the update (in the corresponding commit) that changes              //
+         // joinConnectionList.matchesJoinPath to allow flipped joins to match.                       //
+         // it isn't entirely a valid use-case (to have essentially the same join exposed twice),     //
+         // but, it makes sure to expose a case that would have failed without the referenced change. //
+         ///////////////////////////////////////////////////////////////////////////////////////////////
+         qInstance.addTable(newTable("A", "id")
+            .withExposedJoin(new ExposedJoin().withJoinTable("B").withLabel("B1").withJoinPath(List.of("AB")))
+            .withExposedJoin(new ExposedJoin().withJoinTable("B").withLabel("B2").withJoinPath(List.of("BA")))
+         );
+         qInstance.addTable(newTable("B", "id", "aId"));
+         qInstance.addJoin(new QJoinMetaData().withLeftTable("A").withRightTable("B").withName("AB").withType(JoinType.ONE_TO_ONE).withJoinOn(new JoinOn("id", "aId")));
+         qInstance.addJoin(new QJoinMetaData().withLeftTable("B").withRightTable("A").withName("BA").withType(JoinType.ONE_TO_ONE).withJoinOn(new JoinOn("aId", "id")));
       });
    }
 

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContextTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContextTest.java
@@ -29,6 +29,7 @@ import com.kingsrook.qqq.backend.core.exceptions.QException;
 import com.kingsrook.qqq.backend.core.model.metadata.QAuthenticationType;
 import com.kingsrook.qqq.backend.core.model.metadata.QBackendMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
+import com.kingsrook.qqq.backend.core.model.metadata.authentication.AuthScope;
 import com.kingsrook.qqq.backend.core.model.metadata.authentication.QAuthenticationMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.fields.QFieldMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.fields.QFieldType;
@@ -98,7 +99,7 @@ class JoinsContextTest extends BaseTest
    private QInstance buildBaseInstance()
    {
       QInstance instance = new QInstance();
-      instance.setAuthentication(new QAuthenticationMetaData().withName("mock").withType(QAuthenticationType.MOCK));
+      instance.registerAuthenticationProvider(AuthScope.instanceDefault(), new QAuthenticationMetaData().withName("mock").withType(QAuthenticationType.MOCK));
       instance.addBackend(new QBackendMetaData().withName(BACKEND_NAME).withBackendType(MemoryBackendModule.class));
 
       ////////////
@@ -301,8 +302,13 @@ class JoinsContextTest extends BaseTest
       // use employee→employeeDetail — only one join between these two tables,   //
       // so metadata auto-resolution is unambiguous.                              //
       /////////////////////////////////////////////////////////////////////////////
-      QueryJoin    detailJoin   = new QueryJoin().withJoinTable(EMPLOYEE_DETAIL_TABLE);
-      JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(detailJoin), new QQueryFilter());
+      QueryJoin detailJoin = new QueryJoin().withJoinTable(EMPLOYEE_DETAIL_TABLE);
+
+      ////////////////////////////////////////////////////////////////////////////////////
+      // constructing this joinsContext has the side-effect of modifying the QueryJoin  //
+      // with its QJoinMetaData (thus, no need to capture the constructed JoinsContext) //
+      ////////////////////////////////////////////////////////////////////////////////////
+      new JoinsContext(instance, EMPLOYEE_TABLE, List.of(detailJoin), new QQueryFilter());
 
       QJoinMetaData resolvedMetaData = detailJoin.getJoinMetaData();
       assertNotNull(resolvedMetaData, "JoinMetaData should have been auto-filled");

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContextTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContextTest.java
@@ -1,0 +1,1531 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2022.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.model.actions.tables.query;
+
+
+import java.util.List;
+import com.kingsrook.qqq.backend.core.BaseTest;
+import com.kingsrook.qqq.backend.core.context.QContext;
+import com.kingsrook.qqq.backend.core.exceptions.QException;
+import com.kingsrook.qqq.backend.core.model.metadata.QAuthenticationType;
+import com.kingsrook.qqq.backend.core.model.metadata.QBackendMetaData;
+import com.kingsrook.qqq.backend.core.model.metadata.QInstance;
+import com.kingsrook.qqq.backend.core.model.metadata.authentication.QAuthenticationMetaData;
+import com.kingsrook.qqq.backend.core.model.metadata.fields.QFieldMetaData;
+import com.kingsrook.qqq.backend.core.model.metadata.fields.QFieldType;
+import com.kingsrook.qqq.backend.core.model.metadata.joins.JoinOn;
+import com.kingsrook.qqq.backend.core.model.metadata.joins.JoinType;
+import com.kingsrook.qqq.backend.core.model.metadata.joins.QJoinMetaData;
+import com.kingsrook.qqq.backend.core.model.metadata.security.MultiRecordSecurityLock;
+import com.kingsrook.qqq.backend.core.model.metadata.security.QSecurityKeyType;
+import com.kingsrook.qqq.backend.core.model.metadata.security.RecordSecurityLock;
+import com.kingsrook.qqq.backend.core.model.metadata.tables.ExposedJoin;
+import com.kingsrook.qqq.backend.core.model.metadata.tables.QTableMetaData;
+import com.kingsrook.qqq.backend.core.model.session.QSession;
+import com.kingsrook.qqq.backend.core.modules.backend.implementations.memory.MemoryBackendModule;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/*******************************************************************************
+ ** Unit tests for {@link JoinsContext}.
+ **
+ ** Uses a "company hierarchy" metadata model with 6 tables and 12 joins:
+ ** <pre>
+ **   company 1:N department 1:N employee 1:1 employeeDetail
+ **               department N:1 employee (manager)
+ **                              employee N:1 employee (mentor, self-join)
+ **                              employee 1:N jobHistory N:1 jobTitle
+ ** </pre>
+ *******************************************************************************/
+class JoinsContextTest extends BaseTest
+{
+   private static final String BACKEND_NAME = "memory";
+
+   private static final String COMPANY_TABLE         = "company";
+   private static final String DEPARTMENT_TABLE      = "department";
+   private static final String EMPLOYEE_TABLE        = "employee";
+   private static final String EMPLOYEE_DETAIL_TABLE = "employeeDetail";
+   private static final String JOB_TITLE_TABLE       = "jobTitle";
+   private static final String JOB_HISTORY_TABLE     = "jobHistory";
+
+   private static final String COMPANY_JOIN_DEPARTMENT          = "companyDepartments";
+   private static final String DEPARTMENT_JOIN_COMPANY          = "departmentCompany";
+   private static final String DEPARTMENT_JOIN_EMPLOYEE         = "departmentEmployees";
+   private static final String EMPLOYEE_JOIN_DEPARTMENT         = "employeeDepartment";
+   private static final String EMPLOYEE_JOIN_EMPLOYEE_AS_MENTOR = "employeeMentor";
+   private static final String EMPLOYEE_JOIN_EMPLOYEE_DETAIL    = "employeeEmployeeDetail";
+   private static final String EMPLOYEE_DETAIL_JOIN_EMPLOYEE    = "employeeDetailEmployee";
+   private static final String EMPLOYEE_JOIN_JOB_HISTORY        = "employeeJobHistories";
+   private static final String JOB_HISTORY_JOIN_EMPLOYEE        = "jobHistoryEmployee";
+   private static final String JOB_HISTORY_JOIN_JOB_TITLE       = "jobHistoryJobTitle";
+   private static final String JOB_TITLE_JOIN_JOB_HISTORY       = "jobTitleJobHistories";
+   private static final String DEPARTMENT_JOIN_MANAGER          = "departmentManager";
+
+   private static final String SECURITY_KEY_TYPE_COMPANY       = "companyKey";
+   private static final String SECURITY_KEY_COMPANY_ALL_ACCESS = "companyAllAccess";
+
+
+
+   /***************************************************************************
+    ** Build the base QInstance with 6 tables and 12 joins, no security locks.
+    ***************************************************************************/
+   private QInstance buildBaseInstance()
+   {
+      QInstance instance = new QInstance();
+      instance.setAuthentication(new QAuthenticationMetaData().withName("mock").withType(QAuthenticationType.MOCK));
+      instance.addBackend(new QBackendMetaData().withName(BACKEND_NAME).withBackendType(MemoryBackendModule.class));
+
+      ////////////
+      // Tables //
+      ////////////
+      instance.addTable(new QTableMetaData()
+         .withName(COMPANY_TABLE)
+         .withBackendName(BACKEND_NAME)
+         .withPrimaryKeyField("id")
+         .withField(new QFieldMetaData("id", QFieldType.INTEGER))
+         .withField(new QFieldMetaData("name", QFieldType.STRING))
+         .withField(new QFieldMetaData("industry", QFieldType.STRING))
+         .withField(new QFieldMetaData("foundedDate", QFieldType.DATE)));
+
+      instance.addTable(new QTableMetaData()
+         .withName(DEPARTMENT_TABLE)
+         .withBackendName(BACKEND_NAME)
+         .withPrimaryKeyField("id")
+         .withField(new QFieldMetaData("id", QFieldType.INTEGER))
+         .withField(new QFieldMetaData("companyId", QFieldType.INTEGER))
+         .withField(new QFieldMetaData("managerId", QFieldType.INTEGER))
+         .withField(new QFieldMetaData("name", QFieldType.STRING))
+         .withField(new QFieldMetaData("budget", QFieldType.DECIMAL)));
+
+      instance.addTable(new QTableMetaData()
+         .withName(EMPLOYEE_TABLE)
+         .withBackendName(BACKEND_NAME)
+         .withPrimaryKeyField("id")
+         .withField(new QFieldMetaData("id", QFieldType.INTEGER))
+         .withField(new QFieldMetaData("departmentId", QFieldType.INTEGER))
+         .withField(new QFieldMetaData("mentorEmployeeId", QFieldType.INTEGER))
+         .withField(new QFieldMetaData("firstName", QFieldType.STRING))
+         .withField(new QFieldMetaData("lastName", QFieldType.STRING))
+         .withField(new QFieldMetaData("email", QFieldType.STRING))
+         .withField(new QFieldMetaData("hireDate", QFieldType.DATE))
+         .withField(new QFieldMetaData("isActive", QFieldType.BOOLEAN)));
+
+      instance.addTable(new QTableMetaData()
+         .withName(EMPLOYEE_DETAIL_TABLE)
+         .withBackendName(BACKEND_NAME)
+         .withPrimaryKeyField("id")
+         .withField(new QFieldMetaData("id", QFieldType.INTEGER))
+         .withField(new QFieldMetaData("employeeId", QFieldType.INTEGER))
+         .withField(new QFieldMetaData("phone", QFieldType.STRING))
+         .withField(new QFieldMetaData("emergencyContact", QFieldType.STRING))
+         .withField(new QFieldMetaData("salary", QFieldType.DECIMAL))
+         .withField(new QFieldMetaData("benefitsTier", QFieldType.STRING)));
+
+      instance.addTable(new QTableMetaData()
+         .withName(JOB_TITLE_TABLE)
+         .withBackendName(BACKEND_NAME)
+         .withPrimaryKeyField("id")
+         .withField(new QFieldMetaData("id", QFieldType.INTEGER))
+         .withField(new QFieldMetaData("name", QFieldType.STRING))
+         .withField(new QFieldMetaData("grade", QFieldType.STRING))
+         .withField(new QFieldMetaData("isExempt", QFieldType.BOOLEAN)));
+
+      instance.addTable(new QTableMetaData()
+         .withName(JOB_HISTORY_TABLE)
+         .withBackendName(BACKEND_NAME)
+         .withPrimaryKeyField("id")
+         .withField(new QFieldMetaData("id", QFieldType.INTEGER))
+         .withField(new QFieldMetaData("employeeId", QFieldType.INTEGER))
+         .withField(new QFieldMetaData("jobTitleId", QFieldType.INTEGER))
+         .withField(new QFieldMetaData("startDate", QFieldType.DATE))
+         .withField(new QFieldMetaData("endDate", QFieldType.DATE))
+         .withField(new QFieldMetaData("salaryAtTime", QFieldType.DECIMAL)));
+
+      ///////////
+      // Joins //
+      ///////////
+      instance.addJoin(new QJoinMetaData().withName(COMPANY_JOIN_DEPARTMENT)
+         .withLeftTable(COMPANY_TABLE).withRightTable(DEPARTMENT_TABLE)
+         .withType(JoinType.ONE_TO_MANY).withJoinOn(new JoinOn("id", "companyId")));
+
+      instance.addJoin(new QJoinMetaData().withName(DEPARTMENT_JOIN_EMPLOYEE)
+         .withLeftTable(DEPARTMENT_TABLE).withRightTable(EMPLOYEE_TABLE)
+         .withType(JoinType.ONE_TO_MANY).withJoinOn(new JoinOn("id", "departmentId")));
+
+      instance.addJoin(new QJoinMetaData().withName(EMPLOYEE_JOIN_EMPLOYEE_AS_MENTOR)
+         .withLeftTable(EMPLOYEE_TABLE).withRightTable(EMPLOYEE_TABLE)
+         .withType(JoinType.MANY_TO_ONE).withJoinOn(new JoinOn("mentorEmployeeId", "id")));
+
+      instance.addJoin(new QJoinMetaData().withName(EMPLOYEE_JOIN_EMPLOYEE_DETAIL)
+         .withLeftTable(EMPLOYEE_TABLE).withRightTable(EMPLOYEE_DETAIL_TABLE)
+         .withType(JoinType.ONE_TO_ONE).withJoinOn(new JoinOn("id", "employeeId")));
+
+      instance.addJoin(new QJoinMetaData().withName(EMPLOYEE_JOIN_JOB_HISTORY)
+         .withLeftTable(EMPLOYEE_TABLE).withRightTable(JOB_HISTORY_TABLE)
+         .withType(JoinType.ONE_TO_MANY).withJoinOn(new JoinOn("id", "employeeId")));
+
+      instance.addJoin(new QJoinMetaData().withName(JOB_HISTORY_JOIN_JOB_TITLE)
+         .withLeftTable(JOB_HISTORY_TABLE).withRightTable(JOB_TITLE_TABLE)
+         .withType(JoinType.MANY_TO_ONE).withJoinOn(new JoinOn("jobTitleId", "id")));
+
+      instance.addJoin(new QJoinMetaData().withName(DEPARTMENT_JOIN_MANAGER)
+         .withLeftTable(DEPARTMENT_TABLE).withRightTable(EMPLOYEE_TABLE)
+         .withType(JoinType.MANY_TO_ONE).withJoinOn(new JoinOn("managerId", "id")));
+
+      return (instance);
+   }
+
+
+
+   /***************************************************************************
+    ** Add a "companyKey" security key type and a record security lock on the
+    ** company table's "id" field.
+    ***************************************************************************/
+   private void addCompanySecurityLock(QInstance instance)
+   {
+      addCompanySecurityLock(instance, RecordSecurityLock.NullValueBehavior.DENY);
+   }
+
+
+
+   /***************************************************************************
+    ** Add a "companyKey" security key type and a record security lock on the
+    ** company table's "id" field, with a specified null-value behavior.
+    ***************************************************************************/
+   private void addCompanySecurityLock(QInstance instance, RecordSecurityLock.NullValueBehavior nullValueBehavior)
+   {
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(SECURITY_KEY_TYPE_COMPANY)
+         .withAllAccessKeyName(SECURITY_KEY_COMPANY_ALL_ACCESS));
+
+      instance.getTable(COMPANY_TABLE).withRecordSecurityLock(new RecordSecurityLock()
+         .withSecurityKeyType(SECURITY_KEY_TYPE_COMPANY)
+         .withFieldName("id")
+         .withNullValueBehavior(nullValueBehavior));
+   }
+
+
+
+   /***************************************************************************
+    ** Use the given instance in QContext (replacing the default one from BaseTest).
+    ***************************************************************************/
+   private void useInstance(QInstance instance)
+   {
+      reInitInstanceInContext(instance);
+   }
+
+
+
+   /*******************************************************************************
+    ** Basic construction with no joins and no filter — verifies empty queryJoins
+    ** and table presence checks.
+    *******************************************************************************/
+   @Test
+   void testBasicConstructionNoJoinsNoFilter() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      JoinsContext joinsContext = new JoinsContext(instance, COMPANY_TABLE, List.of(), new QQueryFilter());
+
+      assertTrue(joinsContext.getQueryJoins().isEmpty());
+      assertTrue(joinsContext.hasTable(COMPANY_TABLE));
+      assertFalse(joinsContext.hasTable(DEPARTMENT_TABLE));
+      assertTrue(joinsContext.hasAliasOrTable(COMPANY_TABLE));
+   }
+
+
+
+   /*******************************************************************************
+    ** Explicit QueryJoin for a table — verifies it's processed and the table is
+    ** visible in the context.
+    *******************************************************************************/
+   @Test
+   void testJoinProcessing() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      QueryJoin departmentJoin = new QueryJoin()
+         .withJoinTable(DEPARTMENT_TABLE)
+         .withType(QueryJoin.Type.INNER)
+         .withJoinMetaData(instance.getJoin(COMPANY_JOIN_DEPARTMENT));
+      JoinsContext joinsContext = new JoinsContext(instance, COMPANY_TABLE, List.of(departmentJoin), new QQueryFilter());
+
+      assertEquals(1, joinsContext.getQueryJoins().size());
+      assertEquals(DEPARTMENT_TABLE, joinsContext.getQueryJoins().get(0).getJoinTable());
+      assertTrue(joinsContext.hasTable(DEPARTMENT_TABLE));
+      assertTrue(joinsContext.hasAliasOrTable(DEPARTMENT_TABLE));
+      assertEquals(DEPARTMENT_TABLE, joinsContext.resolveTableNameOrAliasToTableName(DEPARTMENT_TABLE));
+   }
+
+
+
+   /*******************************************************************************
+    ** QueryJoin without explicit joinMetaData — verifies that metadata is
+    ** auto-filled from the instance's joins.
+    *******************************************************************************/
+   @Test
+   void testJoinMetaDataResolution() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      /////////////////////////////////////////////////////////////////////////////
+      // use employee→employeeDetail — only one join between these two tables,   //
+      // so metadata auto-resolution is unambiguous.                              //
+      /////////////////////////////////////////////////////////////////////////////
+      QueryJoin    detailJoin   = new QueryJoin().withJoinTable(EMPLOYEE_DETAIL_TABLE);
+      JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(detailJoin), new QQueryFilter());
+
+      QJoinMetaData resolvedMetaData = detailJoin.getJoinMetaData();
+      assertNotNull(resolvedMetaData, "JoinMetaData should have been auto-filled");
+      assertEquals(EMPLOYEE_TABLE, resolvedMetaData.getLeftTable());
+      assertEquals(EMPLOYEE_DETAIL_TABLE, resolvedMetaData.getRightTable());
+   }
+
+
+
+   /*******************************************************************************
+    ** QueryJoin with an alias — verifies alias resolution, hasTable vs hasAliasOrTable
+    ** distinctions.
+    *******************************************************************************/
+   @Test
+   void testAliasManagement() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      QueryJoin managerJoin = new QueryJoin()
+         .withJoinTable(EMPLOYEE_TABLE)
+         .withAlias("mgr")
+         .withJoinMetaData(instance.getJoin(DEPARTMENT_JOIN_MANAGER));
+
+      JoinsContext joinsContext = new JoinsContext(instance, DEPARTMENT_TABLE, List.of(managerJoin), new QQueryFilter());
+
+      assertEquals(EMPLOYEE_TABLE, joinsContext.resolveTableNameOrAliasToTableName("mgr"));
+      assertTrue(joinsContext.hasAliasOrTable("mgr"));
+      assertTrue(joinsContext.hasTable(EMPLOYEE_TABLE));
+
+      ///////////////////////////////////////////////////////////////////////////////////////////////
+      // "employee" is NOT a key in the alias map (the key is "mgr"), so hasAliasOrTable is false. //
+      ///////////////////////////////////////////////////////////////////////////////////////////////
+      assertFalse(joinsContext.hasAliasOrTable(EMPLOYEE_TABLE));
+   }
+
+
+
+   /*******************************************************************************
+    ** Verifies hasTable and hasAliasOrTable behavior with a mix of aliased and
+    ** non-aliased joins.
+    *******************************************************************************/
+   @Test
+   void testHasTableAndHasAliasOrTable() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      JoinsContext joinsContext = new JoinsContext(instance, COMPANY_TABLE, List.of(
+         new QueryJoin().withJoinTable(DEPARTMENT_TABLE).withAlias("dept")
+            .withJoinMetaData(instance.getJoin(COMPANY_JOIN_DEPARTMENT)),
+         new QueryJoin().withJoinTable(EMPLOYEE_TABLE).withBaseTableOrAlias("dept")
+            .withJoinMetaData(instance.getJoin(DEPARTMENT_JOIN_EMPLOYEE))
+      ), new QQueryFilter());
+
+      //////////////////
+      // hasTable     //
+      //////////////////
+      assertTrue(joinsContext.hasTable(COMPANY_TABLE), "main table");
+      assertTrue(joinsContext.hasTable(DEPARTMENT_TABLE), "actual table name for aliased join");
+      assertFalse(joinsContext.hasTable("dept"), "alias is not a table name");
+      assertTrue(joinsContext.hasTable(EMPLOYEE_TABLE), "unaliased join table");
+
+      ////////////////////////
+      // hasAliasOrTable    //
+      ////////////////////////
+      assertTrue(joinsContext.hasAliasOrTable(COMPANY_TABLE), "main table");
+      assertTrue(joinsContext.hasAliasOrTable("dept"), "alias key");
+      assertFalse(joinsContext.hasAliasOrTable(DEPARTMENT_TABLE), "aliased — key is 'dept', not 'department'");
+      assertTrue(joinsContext.hasAliasOrTable(EMPLOYEE_TABLE), "unaliased join — key is table name");
+   }
+
+
+
+   /*******************************************************************************
+    ** getFieldAndTableNameOrAlias — verifies field resolution with and without
+    ** table prefix, and error on malformed input.
+    *******************************************************************************/
+   @Test
+   void testGetFieldAndTableNameOrAlias() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      JoinsContext joinsContext = new JoinsContext(instance, COMPANY_TABLE, List.of(
+         new QueryJoin().withJoinTable(DEPARTMENT_TABLE)
+            .withJoinMetaData(instance.getJoin(COMPANY_JOIN_DEPARTMENT))
+      ), new QQueryFilter());
+
+      //////////////////////////////////////////////////
+      // unqualified field → resolved from main table //
+      //////////////////////////////////////////////////
+      JoinsContext.FieldAndTableNameOrAlias result = joinsContext.getFieldAndTableNameOrAlias("name");
+      assertEquals(COMPANY_TABLE, result.tableNameOrAlias());
+      assertEquals("name", result.field().getName());
+
+      ////////////////////////////////////////////////////
+      // qualified with joined table name                //
+      ////////////////////////////////////////////////////
+      result = joinsContext.getFieldAndTableNameOrAlias("department.name");
+      assertEquals("department", result.tableNameOrAlias());
+      assertEquals("name", result.field().getName());
+
+      ////////////////////////////////////////////////////
+      // qualified with main table name                  //
+      ////////////////////////////////////////////////////
+      result = joinsContext.getFieldAndTableNameOrAlias("company.industry");
+      assertEquals("company", result.tableNameOrAlias());
+      assertEquals("industry", result.field().getName());
+
+      ///////////////////////////
+      // malformed → exception //
+      ///////////////////////////
+      assertThatThrownBy(() -> joinsContext.getFieldAndTableNameOrAlias("a.b.c"))
+         .isInstanceOf(IllegalArgumentException.class);
+   }
+
+
+
+   /*******************************************************************************
+    ** Filter references a table not in the explicit join list — verifies that
+    ** JoinsContext auto-adds a join for it.
+    *******************************************************************************/
+   @Test
+   void testFilterDrivenJoinAddition() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      QQueryFilter filter = new QQueryFilter()
+         .withCriteria(new QFilterCriteria("department.name", QCriteriaOperator.EQUALS, "Engineering"));
+
+      JoinsContext joinsContext = new JoinsContext(instance, COMPANY_TABLE, List.of(), filter);
+
+      assertEquals(1, joinsContext.getQueryJoins().size());
+      assertEquals(DEPARTMENT_TABLE, joinsContext.getQueryJoins().get(0).getJoinTable());
+      assertNotNull(joinsContext.getQueryJoins().get(0).getJoinMetaData(), "metadata should have been auto-filled");
+   }
+
+
+
+   /*******************************************************************************
+    * Filter references a table not in the explicit join list that is not directly
+    * joined with the table being queried.  Noting that to find such an indirect
+    * join at this time, the main table must have the far-away table identified as
+    * an exposed join...
+    *******************************************************************************/
+   @Test
+   void testFilterDrivenJoinAdditionNotDirectlyJoinedToMainTableButFoundAsExposedJoin() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+
+      instance.getTable(COMPANY_TABLE)
+         .withExposedJoin(new ExposedJoin().withJoinTable(EMPLOYEE_TABLE).withLabel("Employees").withJoinPath(List.of(COMPANY_JOIN_DEPARTMENT, DEPARTMENT_JOIN_EMPLOYEE)));
+
+      useInstance(instance);
+
+      QQueryFilter filter = new QQueryFilter()
+         .withCriteria(new QFilterCriteria("employee.firstName", QCriteriaOperator.EQUALS, "Dave"));
+
+      JoinsContext joinsContext = new JoinsContext(instance, COMPANY_TABLE, List.of(), filter);
+
+      assertEquals(2, joinsContext.getQueryJoins().size());
+      assertEquals(EMPLOYEE_TABLE, joinsContext.getQueryJoins().get(0).getJoinTable());
+      assertEquals(DEPARTMENT_TABLE, joinsContext.getQueryJoins().get(1).getJoinTable());
+      assertNotNull(joinsContext.getQueryJoins().get(0).getJoinMetaData(), "metadata should have been populated");
+      assertNotNull(joinsContext.getQueryJoins().get(1).getJoinMetaData(), "metadata should have been populated");
+   }
+
+
+
+   /*******************************************************************************
+    ** findJoinMetaData — verifies forward/reverse lookup and null for no direct join.
+    *******************************************************************************/
+   @Test
+   void testFindJoinMetaData() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      //////////////////////////////////////////////////////////////////////
+      // use employee as main table — only 1 join to employeeDetail,     //
+      // so lookup is unambiguous                                         //
+      //////////////////////////////////////////////////////////////////////
+      JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(), new QQueryFilter());
+
+      /////////////////////
+      // forward lookup  //
+      /////////////////////
+      QJoinMetaData found = joinsContext.findJoinMetaData(EMPLOYEE_TABLE, EMPLOYEE_DETAIL_TABLE, true);
+      assertNotNull(found);
+      assertThat(found.getName()).isIn(EMPLOYEE_JOIN_EMPLOYEE_DETAIL, EMPLOYEE_DETAIL_JOIN_EMPLOYEE);
+
+      /////////////////////
+      // reverse lookup  //
+      /////////////////////
+      found = joinsContext.findJoinMetaData(EMPLOYEE_DETAIL_TABLE, EMPLOYEE_TABLE, true);
+      assertNotNull(found);
+
+      /////////////////////////////
+      // no direct join → null   //
+      /////////////////////////////
+      found = joinsContext.findJoinMetaData(EMPLOYEE_TABLE, JOB_TITLE_TABLE, true);
+      assertNull(found);
+   }
+
+
+
+   /*******************************************************************************
+    ** findJoinMetaData throws when multiple joins match between the same pair of
+    ** tables (e.g., department→employee has both departmentEmployees and
+    ** departmentManager) and exposed joins don't disambiguate.
+    *******************************************************************************/
+   @Test
+   void testFindJoinMetaDataMultipleMatchesThrows() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      ///////////////////////////////////////////////////////////////
+      // department→employee has 2 joins, so ambiguity should fail //
+      ///////////////////////////////////////////////////////////////
+      JoinsContext joinsContext = new JoinsContext(instance, DEPARTMENT_TABLE, List.of(), new QQueryFilter());
+
+      assertThatThrownBy(() -> joinsContext.findJoinMetaData(DEPARTMENT_TABLE, EMPLOYEE_TABLE, false))
+         .isInstanceOf(RuntimeException.class)
+         .hasMessageContaining("More than 1 join was found");
+   }
+
+
+
+   /*******************************************************************************
+    ** Exposed join resolution — an indirect join resolved via an ExposedJoin path.
+    ** Querying company and joining to jobHistory should add intermediate joins
+    ** (department, employee) automatically.
+    *******************************************************************************/
+   @Test
+   void testExposedJoinResolution() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+
+      ////////////////////////////////////////////////////////////////////////////////
+      // add an exposed join on the company table that leads to jobHistory via path //
+      ////////////////////////////////////////////////////////////////////////////////
+      instance.getTable(COMPANY_TABLE).withExposedJoin(new ExposedJoin()
+         .withJoinTable(JOB_HISTORY_TABLE)
+         .withLabel("Job Histories")
+         .withJoinPath(List.of(COMPANY_JOIN_DEPARTMENT, DEPARTMENT_JOIN_EMPLOYEE, EMPLOYEE_JOIN_JOB_HISTORY)));
+
+      useInstance(instance);
+
+      JoinsContext joinsContext = new JoinsContext(instance, COMPANY_TABLE, List.of(
+         new QueryJoin().withJoinTable(JOB_HISTORY_TABLE).withType(QueryJoin.Type.LEFT)
+      ), new QQueryFilter());
+
+      ////////////////////////////////////////////////////////////////////////////////////
+      // should have at least 3 joins: department, employee, jobHistory (the requested  //
+      // one plus intermediates)                                                         //
+      ////////////////////////////////////////////////////////////////////////////////////
+      assertThat(joinsContext.getQueryJoins().size()).isGreaterThanOrEqualTo(3);
+      assertTrue(joinsContext.hasTable(DEPARTMENT_TABLE));
+      assertTrue(joinsContext.hasTable(EMPLOYEE_TABLE));
+      assertTrue(joinsContext.hasTable(JOB_HISTORY_TABLE));
+   }
+
+
+
+   /*******************************************************************************
+    ** RecordSecurityLock on the main table's own field — verifies that the filter
+    ** gets a security sub-filter with an IN criterion.
+    *******************************************************************************/
+   @Test
+   void testSecurityLockOnMainTable() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      addCompanySecurityLock(instance);
+      useInstance(instance);
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 1));
+
+      QQueryFilter filter       = new QQueryFilter();
+      JoinsContext joinsContext = new JoinsContext(instance, COMPANY_TABLE, List.of(), filter);
+
+      ////////////////////////////////////////////////////////////////
+      // no extra joins needed — lock field is on the main table    //
+      ////////////////////////////////////////////////////////////////
+      assertThat(joinsContext.getQueryJoins()).noneMatch(qj -> qj instanceof ImplicitQueryJoinForSecurityLock);
+
+      ///////////////////////////////////////////////////////////
+      // filter should have a security sub-filter with IN (1)  //
+      ///////////////////////////////////////////////////////////
+      assertThat(filter.getSubFilters()).isNotEmpty();
+      QFilterCriteria securityCriteria = findSecurityCriteria(filter);
+      assertNotNull(securityCriteria, "Should find a security criterion");
+      assertEquals(QCriteriaOperator.IN, securityCriteria.getOperator());
+      assertThat(securityCriteria.getValues()).contains(1);
+   }
+
+
+
+   /*******************************************************************************
+    ** All-access key bypasses security filter — verifies no security sub-filters
+    ** are added when the session has the all-access key.
+    *******************************************************************************/
+   @Test
+   void testSecurityLockAllAccessBypasses() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      addCompanySecurityLock(instance);
+      useInstance(instance);
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_COMPANY_ALL_ACCESS, true));
+
+      QQueryFilter filter = new QQueryFilter();
+      new JoinsContext(instance, COMPANY_TABLE, List.of(), filter);
+
+      ///////////////////////////////////////////////////////////////
+      // with all-access, no security sub-filters should be added //
+      ///////////////////////////////////////////////////////////////
+      assertTrue(filter.getSubFilters() == null || filter.getSubFilters().isEmpty(),
+         "No security sub-filters expected with all-access key");
+   }
+
+
+
+   /*******************************************************************************
+    ** NullValueBehavior.ALLOW with empty session — verifies IS_BLANK criterion.
+    *******************************************************************************/
+   @Test
+   void testSecurityLockNullValueBehaviorAllow() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      addCompanySecurityLock(instance, RecordSecurityLock.NullValueBehavior.ALLOW);
+      useInstance(instance);
+      QContext.setQSession(new QSession());
+
+      QQueryFilter filter = new QQueryFilter();
+      new JoinsContext(instance, COMPANY_TABLE, List.of(), filter);
+
+      QFilterCriteria securityCriteria = findSecurityCriteria(filter);
+      assertNotNull(securityCriteria, "Should find a security criterion");
+      assertEquals(QCriteriaOperator.IS_BLANK, securityCriteria.getOperator());
+   }
+
+
+
+   /*******************************************************************************
+    ** NullValueBehavior.DENY with empty session — verifies FALSE criterion (no rows).
+    *******************************************************************************/
+   @Test
+   void testSecurityLockNullValueBehaviorDeny() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      addCompanySecurityLock(instance, RecordSecurityLock.NullValueBehavior.DENY);
+      useInstance(instance);
+      QContext.setQSession(new QSession());
+
+      QQueryFilter filter = new QQueryFilter();
+      new JoinsContext(instance, COMPANY_TABLE, List.of(), filter);
+
+      QFilterCriteria securityCriteria = findSecurityCriteria(filter);
+      assertNotNull(securityCriteria, "Should find a security criterion");
+      assertEquals(QCriteriaOperator.FALSE, securityCriteria.getOperator());
+   }
+
+
+
+   /*******************************************************************************
+    ** Security lock with a single-hop joinNameChain — verifies that an
+    ** ImplicitQueryJoinForSecurityLock is added.
+    *******************************************************************************/
+   @Test
+   void testSecurityLockWithJoinChain() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(SECURITY_KEY_TYPE_COMPANY)
+         .withAllAccessKeyName(SECURITY_KEY_COMPANY_ALL_ACCESS));
+
+      instance.getTable(DEPARTMENT_TABLE).withRecordSecurityLock(new RecordSecurityLock()
+         .withSecurityKeyType(SECURITY_KEY_TYPE_COMPANY)
+         .withFieldName("company.id")
+         .withJoinNameChain(List.of(COMPANY_JOIN_DEPARTMENT)));
+
+      useInstance(instance);
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 42));
+
+      QQueryFilter filter       = new QQueryFilter();
+      JoinsContext joinsContext = new JoinsContext(instance, DEPARTMENT_TABLE, List.of(), filter);
+
+      /////////////////////////////////////////////////////////////////////
+      // should have an ImplicitQueryJoinForSecurityLock in the join list //
+      /////////////////////////////////////////////////////////////////////
+      assertThat(joinsContext.getQueryJoins())
+         .anyMatch(qj -> qj instanceof ImplicitQueryJoinForSecurityLock);
+
+      //////////////////////////////////////////////////////////
+      // the implicit join should have an alias containing     //
+      // "_forSecurityJoin_"                                   //
+      //////////////////////////////////////////////////////////
+      QueryJoin securityJoin = joinsContext.getQueryJoins().stream()
+         .filter(qj -> qj instanceof ImplicitQueryJoinForSecurityLock)
+         .findFirst().orElseThrow();
+      assertThat(securityJoin.getAlias()).contains("_forSecurityJoin_");
+   }
+
+
+
+   /*******************************************************************************
+    ** Security lock with a multi-hop joinNameChain — verifies multiple implicit
+    ** joins are added.
+    *******************************************************************************/
+   @Test
+   void testSecurityLockMultiHopJoinChain() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(SECURITY_KEY_TYPE_COMPANY)
+         .withAllAccessKeyName(SECURITY_KEY_COMPANY_ALL_ACCESS));
+
+      instance.getTable(EMPLOYEE_TABLE).withRecordSecurityLock(new RecordSecurityLock()
+         .withSecurityKeyType(SECURITY_KEY_TYPE_COMPANY)
+         .withFieldName("company.id")
+         .withJoinNameChain(List.of(COMPANY_JOIN_DEPARTMENT, DEPARTMENT_JOIN_EMPLOYEE)));
+
+      useInstance(instance);
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 7));
+
+      QQueryFilter filter       = new QQueryFilter();
+      JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(), filter);
+
+      ////////////////////////////////////////////////////
+      // should have 2 ImplicitQueryJoinForSecurityLock  //
+      ////////////////////////////////////////////////////
+      long implicitCount = joinsContext.getQueryJoins().stream()
+         .filter(qj -> qj instanceof ImplicitQueryJoinForSecurityLock)
+         .count();
+      assertEquals(2, implicitCount, "Should have 2 implicit security joins for 2-hop chain");
+   }
+
+
+
+   /*******************************************************************************
+    ** MultiRecordSecurityLock with OR operator — verifies OR sub-filter is created
+    ** and implicit joins are LEFT type.
+    *******************************************************************************/
+   @Test
+   void testMultiRecordSecurityLocksOr() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+
+      String departmentKeyType = "departmentKey";
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(SECURITY_KEY_TYPE_COMPANY)
+         .withAllAccessKeyName(SECURITY_KEY_COMPANY_ALL_ACCESS));
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(departmentKeyType));
+
+      instance.getTable(EMPLOYEE_TABLE).withRecordSecurityLock(new MultiRecordSecurityLock()
+         .withOperator(MultiRecordSecurityLock.BooleanOperator.OR)
+         .withLock(new RecordSecurityLock()
+            .withSecurityKeyType(SECURITY_KEY_TYPE_COMPANY)
+            .withFieldName("company.id")
+            .withJoinNameChain(List.of(COMPANY_JOIN_DEPARTMENT, DEPARTMENT_JOIN_EMPLOYEE)))
+         .withLock(new RecordSecurityLock()
+            .withSecurityKeyType(departmentKeyType)
+            .withFieldName("departmentId")));
+
+      useInstance(instance);
+      QContext.setQSession(new QSession()
+         .withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 1)
+         .withSecurityKeyValue(departmentKeyType, 10));
+
+      QQueryFilter filter       = new QQueryFilter();
+      JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(), filter);
+
+      /////////////////////////////////////////////////////////////////
+      // the filter should contain an OR sub-filter for the two locks //
+      /////////////////////////////////////////////////////////////////
+      assertThat(filter.getSubFilters()).isNotEmpty();
+      boolean foundOr = hasSubFilterWithOperator(filter, QQueryFilter.BooleanOperator.OR);
+      assertTrue(foundOr, "Should have an OR sub-filter for the multi-lock");
+
+      ///////////////////////////////////////////////////////////////////////////
+      // implicit security joins in an OR context should be LEFT (not INNER)   //
+      ///////////////////////////////////////////////////////////////////////////
+      joinsContext.getQueryJoins().stream()
+         .filter(qj -> qj instanceof ImplicitQueryJoinForSecurityLock)
+         .forEach(qj -> assertEquals(QueryJoin.Type.LEFT, qj.getType(),
+            "Implicit security join in OR context should be LEFT"));
+   }
+
+
+
+   /*******************************************************************************
+    ** omitSecurity constructor — verifies no security joins/filters are added
+    ** even when a security lock is defined.
+    *******************************************************************************/
+   @Test
+   void testOmitSecurityConstructor() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      addCompanySecurityLock(instance);
+      useInstance(instance);
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 1));
+
+      QQueryFilter filter       = new QQueryFilter();
+      JoinsContext joinsContext = new JoinsContext(COMPANY_TABLE, filter, true);
+
+      assertTrue(joinsContext.getQueryJoins().isEmpty());
+      assertTrue(filter.getSubFilters() == null || filter.getSubFilters().isEmpty(),
+         "No security sub-filters with omitSecurity=true");
+   }
+
+
+
+   /*******************************************************************************
+    ** OR input filter with security — verifies the filter is restructured:
+    ** the original OR becomes a sub-filter inside a new AND, alongside the
+    ** security filter.
+    *******************************************************************************/
+   @Test
+   void testOrFilterWithSecurity() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      addCompanySecurityLock(instance);
+      useInstance(instance);
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 1));
+
+      QQueryFilter filter = new QQueryFilter()
+         .withBooleanOperator(QQueryFilter.BooleanOperator.OR)
+         .withCriteria(new QFilterCriteria("name", QCriteriaOperator.EQUALS, "Acme"))
+         .withCriteria(new QFilterCriteria("industry", QCriteriaOperator.EQUALS, "Tech"));
+
+      new JoinsContext(instance, COMPANY_TABLE, List.of(), filter);
+
+      /////////////////////////////////////////////////////////////////////////
+      // the top-level filter should now be AND (wrapping the original OR)   //
+      /////////////////////////////////////////////////////////////////////////
+      assertEquals(QQueryFilter.BooleanOperator.AND, filter.getBooleanOperator());
+
+      /////////////////////////////////////////////////////////////////////////////
+      // one sub-filter should be the original OR; another should be security    //
+      /////////////////////////////////////////////////////////////////////////////
+      assertThat(filter.getSubFilters()).hasSizeGreaterThanOrEqualTo(2);
+      boolean hasOrSub = filter.getSubFilters().stream()
+         .anyMatch(sf -> sf.getBooleanOperator() == QQueryFilter.BooleanOperator.OR);
+      assertTrue(hasOrSub, "Should have the original OR as a sub-filter");
+   }
+
+
+
+   /*******************************************************************************
+    ** Duplicate alias/table name — verifies QException is thrown.
+    *******************************************************************************/
+   @Test
+   void testDuplicateAliasThrows()
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      assertThatThrownBy(() -> new JoinsContext(instance, COMPANY_TABLE, List.of(
+         new QueryJoin().withJoinTable(DEPARTMENT_TABLE),
+         new QueryJoin().withJoinTable(DEPARTMENT_TABLE)
+      ), new QQueryFilter()))
+         .isInstanceOf(QException.class)
+         .hasMessageContaining("Duplicate table name or alias");
+   }
+
+
+
+   /*******************************************************************************
+    ** Unrecognized join table — verifies QException is thrown.
+    *******************************************************************************/
+   @Test
+   void testUnrecognizedJoinTableThrows()
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      assertThatThrownBy(() -> new JoinsContext(instance, COMPANY_TABLE, List.of(
+         new QueryJoin().withJoinTable("nonExistentTable")
+      ), new QQueryFilter()))
+         .isInstanceOf(QException.class)
+         .hasMessageContaining("Unrecognized name for join table");
+   }
+
+
+
+   /*******************************************************************************
+    ** NullValueBehavior.ALLOW with session values — verifies IS_NULL_OR_IN
+    ** criterion (the user HAS key values AND null records are also allowed).
+    *******************************************************************************/
+   @Test
+   void testSecurityLockNullValueBehaviorAllowWithSessionValues() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      addCompanySecurityLock(instance, RecordSecurityLock.NullValueBehavior.ALLOW);
+      useInstance(instance);
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 5));
+
+      QQueryFilter filter = new QQueryFilter();
+      new JoinsContext(instance, COMPANY_TABLE, List.of(), filter);
+
+      QFilterCriteria securityCriteria = findSecurityCriteria(filter);
+      assertNotNull(securityCriteria, "Should find a security criterion");
+      assertEquals(QCriteriaOperator.IS_NULL_OR_IN, securityCriteria.getOperator());
+      assertThat(securityCriteria.getValues()).contains(5);
+   }
+
+
+
+   /*******************************************************************************
+    ** All-access key in an OR multi-lock context — verifies TRUE operator is used
+    ** for the all-access lock, and implicit joins are LEFT.
+    *******************************************************************************/
+   @Test
+   void testSecurityLockAllAccessInOrContext() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+
+      String departmentKeyType = "departmentKey";
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(SECURITY_KEY_TYPE_COMPANY)
+         .withAllAccessKeyName(SECURITY_KEY_COMPANY_ALL_ACCESS));
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(departmentKeyType));
+
+      instance.getTable(EMPLOYEE_TABLE).withRecordSecurityLock(new MultiRecordSecurityLock()
+         .withOperator(MultiRecordSecurityLock.BooleanOperator.OR)
+         .withLock(new RecordSecurityLock()
+            .withSecurityKeyType(SECURITY_KEY_TYPE_COMPANY)
+            .withFieldName("company.id")
+            .withJoinNameChain(List.of(COMPANY_JOIN_DEPARTMENT, DEPARTMENT_JOIN_EMPLOYEE)))
+         .withLock(new RecordSecurityLock()
+            .withSecurityKeyType(departmentKeyType)
+            .withFieldName("departmentId")));
+
+      useInstance(instance);
+
+      /////////////////////////////////////////////////////////////////////////
+      // user has companyAllAccess = true, but NO departmentKey values at all //
+      /////////////////////////////////////////////////////////////////////////
+      QContext.setQSession(new QSession()
+         .withSecurityKeyValue(SECURITY_KEY_COMPANY_ALL_ACCESS, true));
+
+      QQueryFilter filter       = new QQueryFilter();
+      JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(), filter);
+
+      /////////////////////////////////////////////////////////////////////
+      // should have an OR sub-filter; one child should use TRUE operator //
+      /////////////////////////////////////////////////////////////////////
+      assertTrue(hasSubFilterWithOperator(filter, QQueryFilter.BooleanOperator.OR), "Should have an OR sub-filter");
+      QFilterCriteria trueCriteria = findCriteriaWithOperator(filter, QCriteriaOperator.TRUE);
+      assertNotNull(trueCriteria, "Should have a TRUE criterion for all-access in OR context");
+
+      ////////////////////////////////////////////////////////////////////////
+      // implicit joins in OR context should be LEFT                         //
+      ////////////////////////////////////////////////////////////////////////
+      joinsContext.getQueryJoins().stream()
+         .filter(qj -> qj instanceof ImplicitQueryJoinForSecurityLock)
+         .forEach(qj -> assertEquals(QueryJoin.Type.LEFT, qj.getType(),
+            "Implicit security joins in OR context with all-access should be LEFT"));
+   }
+
+
+
+   /*******************************************************************************
+    ** MultiRecordSecurityLock with AND operator — verifies AND sub-filter is
+    ** created with both criteria as IN.
+    *******************************************************************************/
+   @Test
+   void testMultiRecordSecurityLocksAnd() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+
+      String departmentKeyType = "departmentKey";
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(SECURITY_KEY_TYPE_COMPANY)
+         .withAllAccessKeyName(SECURITY_KEY_COMPANY_ALL_ACCESS));
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(departmentKeyType));
+
+      instance.getTable(EMPLOYEE_TABLE).withRecordSecurityLock(new MultiRecordSecurityLock()
+         .withOperator(MultiRecordSecurityLock.BooleanOperator.AND)
+         .withLock(new RecordSecurityLock()
+            .withSecurityKeyType(SECURITY_KEY_TYPE_COMPANY)
+            .withFieldName("company.id")
+            .withJoinNameChain(List.of(COMPANY_JOIN_DEPARTMENT, DEPARTMENT_JOIN_EMPLOYEE)))
+         .withLock(new RecordSecurityLock()
+            .withSecurityKeyType(departmentKeyType)
+            .withFieldName("departmentId")));
+
+      useInstance(instance);
+      QContext.setQSession(new QSession()
+         .withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 1)
+         .withSecurityKeyValue(departmentKeyType, 10));
+
+      QQueryFilter filter       = new QQueryFilter();
+      JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(), filter);
+
+      ///////////////////////////////////////////////////////////////////
+      // filter should have an AND sub-filter with both criteria as IN //
+      ///////////////////////////////////////////////////////////////////
+      assertThat(filter.getSubFilters()).isNotEmpty();
+      assertTrue(hasSubFilterWithOperator(filter, QQueryFilter.BooleanOperator.AND), "Should have an AND sub-filter for the multi-lock");
+
+      //////////////////////////////////////////////////////////////////////////////////
+      // for AND, implicit security joins should be INNER (not LEFT as they are in OR) //
+      //////////////////////////////////////////////////////////////////////////////////
+      joinsContext.getQueryJoins().stream()
+         .filter(qj -> qj instanceof ImplicitQueryJoinForSecurityLock)
+         .forEach(qj -> assertEquals(QueryJoin.Type.INNER, qj.getType(),
+            "Implicit security joins in AND context should be INNER"));
+   }
+
+
+
+   /*******************************************************************************
+    ** Security lock join chain walk hits an existing join — verifies no
+    ** ImplicitQueryJoinForSecurityLock is created for that hop (reuses existing).
+    *******************************************************************************/
+   @Test
+   void testSecurityLockJoinChainWithExistingJoin() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(SECURITY_KEY_TYPE_COMPANY)
+         .withAllAccessKeyName(SECURITY_KEY_COMPANY_ALL_ACCESS));
+
+      instance.getTable(DEPARTMENT_TABLE).withRecordSecurityLock(new RecordSecurityLock()
+         .withSecurityKeyType(SECURITY_KEY_TYPE_COMPANY)
+         .withFieldName("company.id")
+         .withJoinNameChain(List.of(COMPANY_JOIN_DEPARTMENT)));
+
+      useInstance(instance);
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 42));
+
+      ///////////////////////////////////////////////////////////////////////////////
+      // user explicitly adds a join to company with the companyDepartments join   //
+      ///////////////////////////////////////////////////////////////////////////////
+      QueryJoin companyJoin = new QueryJoin()
+         .withJoinTable(COMPANY_TABLE)
+         .withType(QueryJoin.Type.INNER)
+         .withJoinMetaData(instance.getJoin(COMPANY_JOIN_DEPARTMENT));
+
+      QQueryFilter filter       = new QQueryFilter();
+      JoinsContext joinsContext = new JoinsContext(instance, DEPARTMENT_TABLE, List.of(companyJoin), filter);
+
+      ////////////////////////////////////////////////////////////////////////////////////
+      // since the user already added the companyDepartments join, no implicit joins     //
+      // should be created for the security lock — the existing join should be reused.   //
+      ////////////////////////////////////////////////////////////////////////////////////
+      long implicitCount = joinsContext.getQueryJoins().stream()
+         .filter(qj -> qj instanceof ImplicitQueryJoinForSecurityLock)
+         .count();
+      assertEquals(0, implicitCount, "No implicit security joins needed — existing join should be reused");
+
+      /////////////////////////////////////////////////////
+      // security criteria should still be applied though //
+      /////////////////////////////////////////////////////
+      QFilterCriteria securityCriteria = findSecurityCriteria(filter);
+      assertNotNull(securityCriteria, "Security criteria should still be applied");
+   }
+
+
+
+   /*******************************************************************************
+    ** Cascading security: company as main table, LEFT join to department,
+    ** department has a security lock on company.id with joinNameChain.
+    ** Verifies implicit security joins inherit the LEFT type from the source join.
+    *******************************************************************************/
+   @Test
+   void testSecurityLockOnJoinedTableCascade() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(SECURITY_KEY_TYPE_COMPANY)
+         .withAllAccessKeyName(SECURITY_KEY_COMPANY_ALL_ACCESS));
+
+      instance.getTable(DEPARTMENT_TABLE).withRecordSecurityLock(new RecordSecurityLock()
+         .withSecurityKeyType(SECURITY_KEY_TYPE_COMPANY)
+         .withFieldName("company.id")
+         .withJoinNameChain(List.of(COMPANY_JOIN_DEPARTMENT)));
+
+      useInstance(instance);
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 1));
+
+      ////////////////////////////////////////////////////////////
+      // company as main table, user adds LEFT join to department //
+      ////////////////////////////////////////////////////////////
+      QueryJoin deptJoin = new QueryJoin()
+         .withJoinTable(DEPARTMENT_TABLE)
+         .withType(QueryJoin.Type.LEFT)
+         .withJoinMetaData(instance.getJoin(COMPANY_JOIN_DEPARTMENT));
+
+      QQueryFilter filter       = new QQueryFilter();
+      JoinsContext joinsContext = new JoinsContext(instance, COMPANY_TABLE, List.of(deptJoin), filter);
+
+      //////////////////////////////////////////////////////////////////////////////
+      // any implicit security joins added for department's lock should also be   //
+      // LEFT (inherited from the source join's type)                              //
+      //////////////////////////////////////////////////////////////////////////////
+      joinsContext.getQueryJoins().stream()
+         .filter(qj -> qj instanceof ImplicitQueryJoinForSecurityLock)
+         .forEach(qj -> assertEquals(QueryJoin.Type.LEFT, qj.getType(),
+            "Implicit security joins should inherit LEFT from source join"));
+   }
+
+
+
+   /*******************************************************************************
+    ** LEFT source join → LEFT implicit security joins when walking the chain.
+    ** Employee as main, LEFT join to department; department has a security lock
+    ** on company.id via 1-hop joinNameChain.
+    *******************************************************************************/
+   @Test
+   void testSecurityLockOnLeftJoinProducesLeftSecurityJoins() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(SECURITY_KEY_TYPE_COMPANY)
+         .withAllAccessKeyName(SECURITY_KEY_COMPANY_ALL_ACCESS));
+
+      instance.getTable(DEPARTMENT_TABLE).withRecordSecurityLock(new RecordSecurityLock()
+         .withSecurityKeyType(SECURITY_KEY_TYPE_COMPANY)
+         .withFieldName("company.id")
+         .withJoinNameChain(List.of(COMPANY_JOIN_DEPARTMENT)));
+
+      useInstance(instance);
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 1));
+
+      ///////////////////////////////////////////////////////////////////////
+      // employee main table, LEFT join to department                       //
+      ///////////////////////////////////////////////////////////////////////
+      QueryJoin deptJoin = new QueryJoin()
+         .withJoinTable(DEPARTMENT_TABLE)
+         .withType(QueryJoin.Type.LEFT)
+         .withJoinMetaData(instance.getJoin(DEPARTMENT_JOIN_EMPLOYEE));
+
+      QQueryFilter filter       = new QQueryFilter();
+      JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(deptJoin), filter);
+
+      ///////////////////////////////////////////////////////////////////////////////
+      // implicit security joins for company should be LEFT (not INNER) because    //
+      // the source join (employee→department) is LEFT                              //
+      ///////////////////////////////////////////////////////////////////////////////
+      joinsContext.getQueryJoins().stream()
+         .filter(qj -> qj instanceof ImplicitQueryJoinForSecurityLock)
+         .forEach(qj -> assertEquals(QueryJoin.Type.LEFT, qj.getType(),
+            "Implicit security joins should be LEFT because source join is LEFT"));
+   }
+
+
+
+   /*******************************************************************************
+    ** Filter with orderBy referencing another table — verifies that a join is
+    ** auto-added for the referenced table.
+    *******************************************************************************/
+   @Test
+   void testFilterWithOrderByDrivenJoin() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      QQueryFilter filter = new QQueryFilter()
+         .withOrderBy(new QFilterOrderBy("department.name"));
+
+      JoinsContext joinsContext = new JoinsContext(instance, COMPANY_TABLE, List.of(), filter);
+
+      assertEquals(1, joinsContext.getQueryJoins().size());
+      assertEquals(DEPARTMENT_TABLE, joinsContext.getQueryJoins().get(0).getJoinTable());
+   }
+
+
+
+   /*******************************************************************************
+    ** Filter with subFilter referencing another table — verifies that a join is
+    ** auto-added for the referenced table.
+    *******************************************************************************/
+   @Test
+   void testFilterWithSubFilterDrivenJoin() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      QQueryFilter subFilter = new QQueryFilter()
+         .withCriteria(new QFilterCriteria("department.name", QCriteriaOperator.EQUALS, "Engineering"));
+
+      QQueryFilter filter       = new QQueryFilter().withSubFilter(subFilter);
+      JoinsContext joinsContext = new JoinsContext(instance, COMPANY_TABLE, List.of(), filter);
+
+      assertEquals(1, joinsContext.getQueryJoins().size());
+      assertEquals(DEPARTMENT_TABLE, joinsContext.getQueryJoins().get(0).getJoinTable());
+   }
+
+
+
+   /*******************************************************************************
+    ** Filter with otherFieldName referencing another table — verifies that a join
+    ** is auto-added for the referenced table.
+    *******************************************************************************/
+   @Test
+   void testFilterWithOtherFieldNameDrivenJoin() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      ///////////////////////////////////////////////////////////////
+      // employee as main table, join to department already present //
+      // filter compares employee.departmentId = department.id      //
+      // using otherFieldName to reference department table         //
+      ///////////////////////////////////////////////////////////////
+      QFilterCriteria criteria = new QFilterCriteria()
+         .withFieldName("departmentId")
+         .withOperator(QCriteriaOperator.EQUALS)
+         .withOtherFieldName("department.id");
+
+      QQueryFilter filter       = new QQueryFilter().withCriteria(criteria);
+      JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(), filter);
+
+      //////////////////////////////////////////////////////////////////////////
+      // the department join should be auto-added because of the otherFieldName //
+      //////////////////////////////////////////////////////////////////////////
+      assertTrue(joinsContext.hasTable(DEPARTMENT_TABLE));
+   }
+
+
+
+   /*******************************************************************************
+    ** fillInMissingJoinMetaData flip detection — when a QueryJoin has joinMetaData
+    ** whose leftTable isn't the main table or any other join's base table,
+    ** the metadata should be flipped.
+    *******************************************************************************/
+   @Test
+   void testJoinMetaDataFlipping() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      ///////////////////////////////////////////////////////////////////////////////
+      // employee as main table; attach joinMetaData with left=department          //
+      // (department is NOT in the query as main or as another join's base table). //
+      // So the code should detect this and flip the metadata.                      //
+      ///////////////////////////////////////////////////////////////////////////////
+      QJoinMetaData deptEmpJoin = instance.getJoin(DEPARTMENT_JOIN_EMPLOYEE);
+      QueryJoin queryJoin = new QueryJoin()
+         .withJoinTable(DEPARTMENT_TABLE)
+         .withJoinMetaData(deptEmpJoin);
+
+      JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(queryJoin), new QQueryFilter());
+
+      /////////////////////////////////////////////////////////////////////////
+      // after construction, the queryJoin's metadata should have been       //
+      // flipped: its leftTable should now be employee (the main table side) //
+      /////////////////////////////////////////////////////////////////////////
+      QJoinMetaData resolvedMetaData = queryJoin.getJoinMetaData();
+      assertNotNull(resolvedMetaData, "JoinMetaData should still be present after flip");
+      assertEquals(EMPLOYEE_TABLE, resolvedMetaData.getLeftTable(), "Left table should be employee (flipped)");
+      assertEquals(DEPARTMENT_TABLE, resolvedMetaData.getRightTable(), "Right table should be department (flipped)");
+   }
+
+
+
+   /*******************************************************************************
+    ** findJoinMetaData with exposed join disambiguation — when multiple joins
+    ** match between two tables, an ExposedJoin can disambiguate.
+    *******************************************************************************/
+   @Test
+   void testFindJoinMetaDataWithExposedJoinDisambiguation() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+
+      //////////////////////////////////////////////////////////////////////////////////
+      // department→employee is ambiguous: departmentEmployees AND departmentManager   //
+      // Add an ExposedJoin on department table to disambiguate                         //
+      //////////////////////////////////////////////////////////////////////////////////
+      instance.getTable(DEPARTMENT_TABLE).withExposedJoin(new ExposedJoin()
+         .withJoinTable(EMPLOYEE_TABLE)
+         .withLabel("Employees")
+         .withJoinPath(List.of(DEPARTMENT_JOIN_EMPLOYEE)));
+
+      useInstance(instance);
+
+      JoinsContext joinsContext = new JoinsContext(instance, DEPARTMENT_TABLE, List.of(), new QQueryFilter());
+
+      //////////////////////////////////////////////////////////////////
+      // This should NOT throw, because the exposed join disambiguates //
+      //////////////////////////////////////////////////////////////////
+      QJoinMetaData found = joinsContext.findJoinMetaData(DEPARTMENT_TABLE, EMPLOYEE_TABLE, true);
+      assertNotNull(found, "Should find a join via exposed join disambiguation");
+      assertEquals(DEPARTMENT_JOIN_EMPLOYEE, found.getName(), "Should resolve to the departmentEmployees join");
+   }
+
+
+
+   /*******************************************************************************
+    ** AND input filter with security — verifies no wrapping occurs (the security
+    ** sub-filter is appended directly to the existing AND filter).
+    *******************************************************************************/
+   @Test
+   void testAndFilterWithSecurity() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      addCompanySecurityLock(instance);
+      useInstance(instance);
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 1));
+
+      QQueryFilter filter = new QQueryFilter()
+         .withBooleanOperator(QQueryFilter.BooleanOperator.AND)
+         .withCriteria(new QFilterCriteria("name", QCriteriaOperator.EQUALS, "Acme"));
+
+      new JoinsContext(instance, COMPANY_TABLE, List.of(), filter);
+
+      ///////////////////////////////////////////////////////////////////////////
+      // the filter should remain AND (no wrapping needed as it was already AND) //
+      ///////////////////////////////////////////////////////////////////////////
+      assertEquals(QQueryFilter.BooleanOperator.AND, filter.getBooleanOperator());
+
+      ///////////////////////////////////////////////
+      // should still have the original criterion  //
+      ///////////////////////////////////////////////
+      assertThat(filter.getCriteria()).anyMatch(c -> c.getFieldName().equals("name"));
+
+      /////////////////////////////////
+      // plus a security sub-filter  //
+      /////////////////////////////////
+      assertThat(filter.getSubFilters()).isNotEmpty();
+      QFilterCriteria securityCriteria = findSecurityCriteria(filter);
+      assertNotNull(securityCriteria, "Should have security criteria");
+      assertEquals(QCriteriaOperator.IN, securityCriteria.getOperator());
+   }
+
+
+
+   /*******************************************************************************
+    ** resolveTableNameOrAliasToTableName with unknown name — verifies it returns
+    ** the input as-is when the name is not in the alias map.
+    *******************************************************************************/
+   @Test
+   void testResolveTableNameOrAliasNotFound() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      JoinsContext joinsContext = new JoinsContext(instance, COMPANY_TABLE, List.of(), new QQueryFilter());
+
+      assertEquals("unknownAlias", joinsContext.resolveTableNameOrAliasToTableName("unknownAlias"),
+         "Unknown name should be returned as-is");
+   }
+
+
+
+   /*******************************************************************************
+    ** Security criteria placed in JOIN ON — when a user-added INNER join
+    ** has a security lock, and the context is NOT an OR multi-lock, the
+    ** lock criteria should be placed in the join's securityCriteria (JOIN ON)
+    ** rather than the WHERE clause.
+    *******************************************************************************/
+   @Test
+   void testSecurityCriteriaPlacedInJoinOn() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(SECURITY_KEY_TYPE_COMPANY)
+         .withAllAccessKeyName(SECURITY_KEY_COMPANY_ALL_ACCESS));
+
+      instance.getTable(DEPARTMENT_TABLE).withRecordSecurityLock(new RecordSecurityLock()
+         .withSecurityKeyType(SECURITY_KEY_TYPE_COMPANY)
+         .withFieldName("company.id")
+         .withJoinNameChain(List.of(COMPANY_JOIN_DEPARTMENT)));
+
+      useInstance(instance);
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 99));
+
+      ////////////////////////////////////////////////////////////////////////////
+      // company as main table, user adds INNER join to department              //
+      ////////////////////////////////////////////////////////////////////////////
+      QueryJoin deptJoin = new QueryJoin()
+         .withJoinTable(DEPARTMENT_TABLE)
+         .withType(QueryJoin.Type.INNER)
+         .withJoinMetaData(instance.getJoin(COMPANY_JOIN_DEPARTMENT));
+
+      QQueryFilter filter       = new QQueryFilter();
+      JoinsContext joinsContext = new JoinsContext(instance, COMPANY_TABLE, List.of(deptJoin), filter);
+
+      ///////////////////////////////////////////////////////////////////////////////
+      // find the query join that corresponds to the security lock chain walk.     //
+      // The security criteria should be placed in JOIN ON (on the matching join), //
+      // NOT in the WHERE clause filter.                                           //
+      ///////////////////////////////////////////////////////////////////////////////
+      boolean foundSecurityCriteriaOnJoin = joinsContext.getQueryJoins().stream()
+         .anyMatch(qj -> qj.getSecurityCriteria() != null && !qj.getSecurityCriteria().isEmpty());
+      assertTrue(foundSecurityCriteriaOnJoin,
+         "Security criteria should be placed in JOIN ON (securityCriteria on QueryJoin), not in WHERE");
+   }
+
+
+
+   /*******************************************************************************
+    ** findJoinMetaData with null baseTableName — verifies it finds any join to
+    ** the target table that has its other side already in the query.
+    *******************************************************************************/
+   @Test
+   void testFindJoinMetaDataNullBaseTable() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      useInstance(instance);
+
+      ///////////////////////////////////////////////////////////////////////////
+      // employee as main table; search for employeeDetail with null base      //
+      // — should find employee→employeeDetail since employee is the main table //
+      ///////////////////////////////////////////////////////////////////////////
+      JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(), new QQueryFilter());
+
+      QJoinMetaData found = joinsContext.findJoinMetaData(null, EMPLOYEE_DETAIL_TABLE, false);
+      assertNotNull(found, "Should find a join to employeeDetail when baseTable is null and employee is main table");
+   }
+
+
+
+   /***************************************************************************
+    ** Recursively search a filter tree for a QFilterCriteria that looks like
+    ** a security criterion (operators: IN, IS_BLANK, IS_NULL_OR_IN, FALSE, TRUE).
+    ***************************************************************************/
+   private QFilterCriteria findSecurityCriteria(QQueryFilter filter)
+   {
+      if(filter == null)
+      {
+         return null;
+      }
+
+      for(QFilterCriteria criteria : filter.getCriteria())
+      {
+         if(isSecurityOperator(criteria.getOperator()))
+         {
+            return criteria;
+         }
+      }
+
+      for(QQueryFilter subFilter : filter.getSubFilters())
+      {
+         QFilterCriteria found = findSecurityCriteria(subFilter);
+         if(found != null)
+         {
+            return found;
+         }
+      }
+
+      return null;
+   }
+
+
+
+   /***************************************************************************
+    **
+    ***************************************************************************/
+   private boolean isSecurityOperator(QCriteriaOperator operator)
+   {
+      return operator == QCriteriaOperator.IN
+         || operator == QCriteriaOperator.IS_BLANK
+         || operator == QCriteriaOperator.IS_NULL_OR_IN
+         || operator == QCriteriaOperator.FALSE
+         || operator == QCriteriaOperator.TRUE;
+   }
+
+
+
+   /***************************************************************************
+    ** Recursively search a filter tree for a QFilterCriteria with the given
+    ** operator.
+    ***************************************************************************/
+   private QFilterCriteria findCriteriaWithOperator(QQueryFilter filter, QCriteriaOperator operator)
+   {
+      if(filter == null)
+      {
+         return null;
+      }
+
+      for(QFilterCriteria criteria : filter.getCriteria())
+      {
+         if(criteria.getOperator() == operator)
+         {
+            return criteria;
+         }
+      }
+
+      for(QQueryFilter subFilter : filter.getSubFilters())
+      {
+         QFilterCriteria found = findCriteriaWithOperator(subFilter, operator);
+         if(found != null)
+         {
+            return found;
+         }
+      }
+
+      return null;
+   }
+
+
+
+   /***************************************************************************
+    ** Recursively check if a filter tree contains a sub-filter with the given
+    ** boolean operator.
+    ***************************************************************************/
+   private boolean hasSubFilterWithOperator(QQueryFilter filter, QQueryFilter.BooleanOperator operator)
+   {
+      if(filter == null)
+      {
+         return false;
+      }
+
+      for(QQueryFilter sub : filter.getSubFilters())
+      {
+         if(sub.getBooleanOperator() == operator)
+         {
+            return true;
+         }
+         if(hasSubFilterWithOperator(sub, operator))
+         {
+            return true;
+         }
+      }
+
+      return false;
+   }
+
+}

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/utils/SortedPairTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/utils/SortedPairTest.java
@@ -1,0 +1,52 @@
+/*
+ * QQQ - Low-code Application Framework for Engineers.
+ * Copyright (C) 2021-2026.  Kingsrook, LLC
+ * 651 N Broad St Ste 205 # 6917 | Middletown DE 19709 | United States
+ * contact@kingsrook.com
+ * https://github.com/Kingsrook/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.kingsrook.qqq.backend.core.utils;
+
+
+import com.kingsrook.qqq.backend.core.BaseTest;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+/*******************************************************************************
+ ** Unit test for SortedPair 
+ *******************************************************************************/
+class SortedPairTest extends BaseTest
+{
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
+   @Test
+   void test()
+   {
+      assertEquals(1, new SortedPair<>(1, 2).getA());
+      assertEquals(2, new SortedPair<>(1, 2).getB());
+
+      assertEquals(1, new SortedPair<>(2, 1).getA());
+      assertEquals(2, new SortedPair<>(2, 1).getB());
+
+      assertEquals(3, new SortedPair<>(3, 3).getA());
+      assertEquals(3, new SortedPair<>(3, 3).getB());
+   }
+
+}

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/utils/SortedPairTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/utils/SortedPairTest.java
@@ -25,6 +25,7 @@ package com.kingsrook.qqq.backend.core.utils;
 import com.kingsrook.qqq.backend.core.BaseTest;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 
 /*******************************************************************************
@@ -47,6 +48,17 @@ class SortedPairTest extends BaseTest
 
       assertEquals(3, new SortedPair<>(3, 3).getA());
       assertEquals(3, new SortedPair<>(3, 3).getB());
+
+      assertNull(new SortedPair<>(null, null).getA());
+      assertNull(new SortedPair<>(null, null).getB());
+
+      ///////////////////////////////////
+      // null compares before non-null //
+      ///////////////////////////////////
+      assertNull(new SortedPair<>(null, 1).getA());
+      assertEquals(1, new SortedPair<>(null, 1).getB());
+      assertNull(new SortedPair<>(1, null).getA());
+      assertEquals(1, new SortedPair<>(1, null).getB());
    }
 
 }


### PR DESCRIPTION
## Summary

Improves join validation and context handling for instances that define bidirectional (flipped) joins between the same pair of tables.

- **JoinGraph flipped-join awareness**: Tracks when A→B and B→A joins exist on the same fields; `matchesJoinPath` now considers either join name as a valid match, preventing false validation failures
- **JoinsContext warning**: Logs a warning when `fillInMissingJoinMetaData` cannot resolve join metadata for a query join
- **Validation message fix**: Corrects error text to say "exposed join" instead of "join"
- **New utility class**: `SortedPair<A,B>` for order-independent pair comparisons
- **Test coverage**: Adds baseline unit tests for `JoinGraph` and comprehensive tests for `JoinsContext`

## Test plan
- [x] Instances with bidirectional joins (A→B and B→A) pass validation
- [x] ExposedJoin paths using either join direction are correctly matched
- [x] Warning is logged when join metadata cannot be found
- [x] `SortedPair` equality works regardless of element order

🤖 Generated with [Claude Code](https://claude.com/claude-code)