### PR TITLE
Feature/fix process build initial filter to read post or get

### DIFF
--- a/qqq-middleware-javalin/pom.xml
+++ b/qqq-middleware-javalin/pom.xml
@@ -66,7 +66,7 @@
       <dependency>
          <groupId>com.kingsrook.qqq</groupId>
          <artifactId>qqq-frontend-material-dashboard</artifactId>
-         <version>0.28.0-20251201.170136-2</version>
+         <version>0.36.1</version>
          <scope>test</scope>
          <optional>true</optional>
       </dependency>

--- a/qqq-middleware-javalin/src/main/java/com/kingsrook/qqq/backend/javalin/QJavalinProcessHandler.java
+++ b/qqq-middleware-javalin/src/main/java/com/kingsrook/qqq/backend/javalin/QJavalinProcessHandler.java
@@ -618,7 +618,7 @@ public class QJavalinProcessHandler
       /////////////////////////////////////////////////////////////
       // deal with params that specify an initial-records filter //
       /////////////////////////////////////////////////////////////
-      QQueryFilter initialRecordsFilter = buildProcessInitRecordsFilter(context, runProcessInput);
+      QQueryFilter initialRecordsFilter = buildProcessInitRecordsFilter(runProcessInput);
       if(initialRecordsFilter != null)
       {
          runProcessInput.setCallback(new QProcessCallback()
@@ -645,7 +645,7 @@ public class QJavalinProcessHandler
    /*******************************************************************************
     **
     *******************************************************************************/
-   private static QQueryFilter buildProcessInitRecordsFilter(Context context, RunProcessInput runProcessInput) throws IOException
+   private static QQueryFilter buildProcessInitRecordsFilter(RunProcessInput runProcessInput) throws IOException
    {
       QInstance        instance = QContext.getQInstance();
       QProcessMetaData process  = instance.getProcess(runProcessInput.getProcessName());
@@ -658,11 +658,11 @@ public class QJavalinProcessHandler
       }
       String primaryKeyField = table.getPrimaryKeyField();
 
-      String recordsParam = context.queryParam("recordsParam");
+      String recordsParam = runProcessInput.getValueString("recordsParam");
       if(StringUtils.hasContent(recordsParam))
       {
          @SuppressWarnings("ConstantConditions")
-         String paramValue = context.queryParam(recordsParam);
+         String paramValue = runProcessInput.getValueString(recordsParam);
          if(!StringUtils.hasContent(paramValue))
          {
             throw (new IllegalArgumentException("Missing value in query parameter: " + recordsParam + " (which was specified as the recordsParam)"));

--- a/qqq-middleware-javalin/src/main/java/com/kingsrook/qqq/backend/javalin/QJavalinProcessHandler.java
+++ b/qqq-middleware-javalin/src/main/java/com/kingsrook/qqq/backend/javalin/QJavalinProcessHandler.java
@@ -661,7 +661,6 @@ public class QJavalinProcessHandler
       String recordsParam = runProcessInput.getValueString("recordsParam");
       if(StringUtils.hasContent(recordsParam))
       {
-         @SuppressWarnings("ConstantConditions")
          String paramValue = runProcessInput.getValueString(recordsParam);
          if(!StringUtils.hasContent(paramValue))
          {
@@ -671,7 +670,6 @@ public class QJavalinProcessHandler
          switch(recordsParam)
          {
             case "recordIds":
-               @SuppressWarnings("ConstantConditions")
                Serializable[] idStrings = paramValue.split(",");
                return (new QQueryFilter().withCriteria(new QFilterCriteria()
                   .withFieldName(primaryKeyField)

--- a/qqq-middleware-javalin/src/test/java/com/kingsrook/qqq/middleware/javalin/QApplicationJavalinServerTest.java
+++ b/qqq-middleware-javalin/src/test/java/com/kingsrook/qqq/middleware/javalin/QApplicationJavalinServerTest.java
@@ -44,7 +44,6 @@ import com.kingsrook.qqq.middleware.javalin.specs.v1.MiddlewareVersionV1;
 import io.javalin.http.HttpStatus;
 import kong.unirest.HttpResponse;
 import kong.unirest.Unirest;
-import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -1961,7 +1960,9 @@ class QApplicationJavalinServerTest
 
 
 
-   @NotNull
+   /*******************************************************************************
+    *
+    *******************************************************************************/
    private static String getMainCssHash(HttpResponse<String> deepLinkResponse)
    {
       return deepLinkResponse.getBody().replaceFirst("(?s).*static/css/main.", "").replaceFirst("(?s).css.*", "");
@@ -1969,7 +1970,9 @@ class QApplicationJavalinServerTest
 
 
 
-   @NotNull
+   /*******************************************************************************
+    *
+    *******************************************************************************/
    private static String getMainJsHash(HttpResponse<String> deepLinkResponse)
    {
       return deepLinkResponse.getBody().replaceFirst("(?s).*static/js/main.", "").replaceFirst("(?s).js.*", "");

--- a/qqq-middleware-javalin/src/test/java/com/kingsrook/qqq/middleware/javalin/QApplicationJavalinServerTest.java
+++ b/qqq-middleware-javalin/src/test/java/com/kingsrook/qqq/middleware/javalin/QApplicationJavalinServerTest.java
@@ -44,6 +44,7 @@ import com.kingsrook.qqq.middleware.javalin.specs.v1.MiddlewareVersionV1;
 import io.javalin.http.HttpStatus;
 import kong.unirest.HttpResponse;
 import kong.unirest.Unirest;
+import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -1931,28 +1932,47 @@ class QApplicationJavalinServerTest
          .as("HTML should contain relative ./static/js path")
          .contains("./static/js/main.");
 
+      String mainJsHash  = getMainJsHash(deepLinkResponse);
+      String mainCssHash = getMainCssHash(deepLinkResponse);
+
       /////////////////////////////////////////////////////////////
       // 2. The CORRECT path: /static/js/main.xxx.js should work //
       // With <base href="/">, the browser resolves ./ from root //
       /////////////////////////////////////////////////////////////
-      HttpResponse<String> correctJsPath = Unirest.get("http://localhost:" + PORT + "/static/js/main.723fb195.js").asString();
+      HttpResponse<String> correctJsPath = Unirest.get("http://localhost:" + PORT + "/static/js/main." + mainJsHash + ".js").asString();
       assertEquals(200, correctJsPath.getStatus(), "CORRECT: /static/js/main.xxx.js should return 200");
 
       //////////////////////////////////////////////////////////////
       // 3. The WRONG path: /someApp/static/js/... should 404     //
       // This is what the browser would request WITHOUT base href //
       //////////////////////////////////////////////////////////////
-      HttpResponse<String> wrongJsPath = Unirest.get("http://localhost:" + PORT + "/someApp/static/js/main.723fb195.js").asString();
+      HttpResponse<String> wrongJsPath = Unirest.get("http://localhost:" + PORT + "/someApp/static/js/main." + mainJsHash + ".js").asString();
       assertEquals(404, wrongJsPath.getStatus(), "WRONG: /someApp/static/js/main.xxx.js should 404");
 
       ////////////////////////////////
       // 4. Same test for CSS files //
       ////////////////////////////////
-      HttpResponse<String> correctCssPath = Unirest.get("http://localhost:" + PORT + "/static/css/main.bb7af874.css").asString();
+      HttpResponse<String> correctCssPath = Unirest.get("http://localhost:" + PORT + "/static/css/main." + mainCssHash + ".css").asString();
       assertEquals(200, correctCssPath.getStatus(), "CORRECT: /static/css/main.xxx.css should return 200");
 
-      HttpResponse<String> wrongCssPath = Unirest.get("http://localhost:" + PORT + "/someApp/static/css/main.bb7af874.css").asString();
+      HttpResponse<String> wrongCssPath = Unirest.get("http://localhost:" + PORT + "/someApp/static/css/main." + mainCssHash + ".css").asString();
       assertEquals(404, wrongCssPath.getStatus(), "WRONG: /someApp/static/css/main.xxx.css should 404");
+   }
+
+
+
+   @NotNull
+   private static String getMainCssHash(HttpResponse<String> deepLinkResponse)
+   {
+      return deepLinkResponse.getBody().replaceFirst("(?s).*static/css/main.", "").replaceFirst("(?s).css.*", "");
+   }
+
+
+
+   @NotNull
+   private static String getMainJsHash(HttpResponse<String> deepLinkResponse)
+   {
+      return deepLinkResponse.getBody().replaceFirst("(?s).*static/js/main.", "").replaceFirst("(?s).js.*", "");
    }
 
 
@@ -1983,10 +2003,17 @@ class QApplicationJavalinServerTest
          .contains("name")
          .doesNotContain("<!doctype");
 
+      //////////////////////////////////////////////////////////////////
+      // fetch the index page, to get the main js file's current hash //
+      //////////////////////////////////////////////////////////////////
+      HttpResponse<String> indexResponse = Unirest.get("http://localhost:" + PORT + "/").asString();
+      assertEquals(200, indexResponse.getStatus());
+      String mainJsHash = getMainJsHash(indexResponse);
+
       /////////////////////////////////////////////////
       // 2. Static JS files should return JavaScript //
       /////////////////////////////////////////////////
-      HttpResponse<String> jsFile = Unirest.get("http://localhost:" + PORT + "/static/js/main.723fb195.js").asString();
+      HttpResponse<String> jsFile = Unirest.get("http://localhost:" + PORT + "/static/js/main." + mainJsHash + ".js").asString();
       assertEquals(200, jsFile.getStatus());
       // Check Content-Type header if present
       String contentType = jsFile.getHeaders().getFirst("Content-Type");
@@ -2033,10 +2060,13 @@ class QApplicationJavalinServerTest
          .as("HTML should have text/html content type")
          .containsIgnoringCase("text/html");
 
+      String mainJsHash  = getMainJsHash(htmlResponse);
+      String mainCssHash = getMainCssHash(htmlResponse);
+
       ////////////////////////////////////////////////////////
       // 2. JavaScript should have appropriate content type //
       ////////////////////////////////////////////////////////
-      HttpResponse<String> jsResponse = Unirest.get("http://localhost:" + PORT + "/static/js/main.723fb195.js").asString();
+      HttpResponse<String> jsResponse = Unirest.get("http://localhost:" + PORT + "/static/js/main." + mainJsHash + ".js").asString();
       assertThat(jsResponse.getHeaders().getFirst("Content-Type"))
          .as("JS should have javascript content type")
          .containsIgnoringCase("javascript");
@@ -2044,7 +2074,7 @@ class QApplicationJavalinServerTest
       //////////////////////////////////////////////
       // 3. CSS should have text/css content type //
       //////////////////////////////////////////////
-      HttpResponse<String> cssResponse = Unirest.get("http://localhost:" + PORT + "/static/css/main.bb7af874.css").asString();
+      HttpResponse<String> cssResponse = Unirest.get("http://localhost:" + PORT + "/static/css/main." + mainCssHash + ".css").asString();
       assertThat(cssResponse.getHeaders().getFirst("Content-Type"))
          .as("CSS should have text/css content type")
          .containsIgnoringCase("text/css");

--- a/qqq-middleware-javalin/src/test/java/com/kingsrook/qqq/middleware/javalin/QApplicationJavalinServerTest.java
+++ b/qqq-middleware-javalin/src/test/java/com/kingsrook/qqq/middleware/javalin/QApplicationJavalinServerTest.java
@@ -1965,7 +1965,9 @@ class QApplicationJavalinServerTest
     *******************************************************************************/
    private static String getMainCssHash(HttpResponse<String> deepLinkResponse)
    {
-      return deepLinkResponse.getBody().replaceFirst("(?s).*static/css/main.", "").replaceFirst("(?s).css.*", "");
+      String hash = deepLinkResponse.getBody().replaceFirst("(?s).*static/css/main.", "").replaceFirst("(?s)\\.css.*", "");
+      assertThat(hash).describedAs("extracted hash for main.x.css").matches("[a-f0-9]+");
+      return hash;
    }
 
 
@@ -1975,7 +1977,9 @@ class QApplicationJavalinServerTest
     *******************************************************************************/
    private static String getMainJsHash(HttpResponse<String> deepLinkResponse)
    {
-      return deepLinkResponse.getBody().replaceFirst("(?s).*static/js/main.", "").replaceFirst("(?s).js.*", "");
+      String hash = deepLinkResponse.getBody().replaceFirst("(?s).*static/js/main.", "").replaceFirst("(?s)\\.js.*", "");
+      assertThat(hash).describedAs("extracted hash for main.x.js").matches("[a-f0-9]+");
+      return hash;
    }
 
 


### PR DESCRIPTION
Fix in QJavalinProcessHandler's buildProcessInitRecordsFilter method, to read parameters from the process's state, rather than assuming they are in the queryString.  This goes along with the a recent change on QFMD https://github.com/QRun-IO/qqq-frontend-material-dashboard/pull/145 to always post instead of get (to avoid length limitations). 

along with this, a QFMD version test dep had to be bumped in javalin (it had been referencing a snapshot version which is now expired), and changing that version exposed an issue in some tests method that had hard-coded react-built file name hashes - so those tests have been improved.  