### PR TITLE
fix(JoinsContext): clone incoming QueryJoins to prevent shared-state mutation

### DIFF
--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContext.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContext.java
@@ -830,6 +830,8 @@ public class JoinsContext
 
                ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
                // check the other joins in this query - if any of them have this join's left-table as their baseTable, then set the flag to true //
+               // also check if any other join's join-table resolves to this left table (handles aliased joins, e.g., security joins that bring  //
+               // a table into the query under an alias like "orderLine_forSecurityJoin_lineItemLineItemExtrinsic")                               //
                ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
                for(QueryJoin otherJoin : queryJoins)
                {
@@ -839,6 +841,13 @@ public class JoinsContext
                   }
 
                   if(Objects.equals(otherJoin.getBaseTableOrAlias(), joinMetaDataLeftTable))
+                  {
+                     isJoinLeftTableInQuery = true;
+                     break;
+                  }
+
+                  String otherJoinTableName = resolveTableNameOrAliasToTableName(otherJoin.getJoinTableOrItsAlias());
+                  if(Objects.equals(otherJoinTableName, joinMetaDataLeftTable))
                   {
                      isJoinLeftTableInQuery = true;
                      break;

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContext.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContext.java
@@ -831,7 +831,7 @@ public class JoinsContext
                ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
                // check the other joins in this query - if any of them have this join's left-table as their baseTable, then set the flag to true //
                // also check if any other join's join-table resolves to this left table (handles aliased joins, e.g., security joins that bring  //
-               // a table into the query under an alias like "orderLine_forSecurityJoin_lineItemLineItemExtrinsic")                               //
+               // a table into the query under an alias like "orderLine_forSecurityJoin_lineItemLineItemExtrinsic")                              //
                ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
                for(QueryJoin otherJoin : queryJoins)
                {

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContext.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContext.java
@@ -176,7 +176,7 @@ public class JoinsContext
    {
       this.instance = instance;
       this.mainTableName = tableName;
-      this.queryJoins = new MutableList<>(queryJoins);
+      this.queryJoins = new ArrayList<>(CollectionUtils.nonNullList(queryJoins).stream().map(QueryJoin::clone).toList());
       this.securityFilter = new QQueryFilter();
       this.securityFilterCursor = this.securityFilter;
 
@@ -622,15 +622,6 @@ public class JoinsContext
       boolean haveAllAccessKey = hasAllAccessKey(recordSecurityLock);
       if(haveAllAccessKey)
       {
-         if(sourceQueryJoin != null)
-         {
-            ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-            // in case the queryJoin object is re-used between queries, and its security criteria need to be different (!!), reset it //
-            // this can be exposed in tests - maybe not entirely expected in real-world, but seems safe enough                        //
-            ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-            sourceQueryJoin.withSecurityCriteria(new ArrayList<>());
-         }
-
          ////////////////////////////////////////////////////////////////////////////////////////
          // if we're in an AND filter, then we don't need a criteria for this lock, so return. //
          ////////////////////////////////////////////////////////////////////////////////////////

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContext.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContext.java
@@ -176,7 +176,13 @@ public class JoinsContext
    {
       this.instance = instance;
       this.mainTableName = tableName;
+
+      /////////////////////////////////////////////////////////////////////////////
+      // clone the incoming query joins - as this class will mutate them!  so in //
+      // case they came from some meta-data, we don't want to change them there. //
+      /////////////////////////////////////////////////////////////////////////////
       this.queryJoins = new ArrayList<>(CollectionUtils.nonNullList(queryJoins).stream().map(QueryJoin::clone).toList());
+
       this.securityFilter = new QQueryFilter();
       this.securityFilterCursor = this.securityFilter;
 

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/modules/backend/implementations/memory/MemoryRecordStore.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/modules/backend/implementations/memory/MemoryRecordStore.java
@@ -62,6 +62,7 @@ import com.kingsrook.qqq.backend.core.model.actions.tables.count.CountInput;
 import com.kingsrook.qqq.backend.core.model.actions.tables.count.CountOutput;
 import com.kingsrook.qqq.backend.core.model.actions.tables.delete.DeleteInput;
 import com.kingsrook.qqq.backend.core.model.actions.tables.insert.InsertInput;
+import com.kingsrook.qqq.backend.core.model.actions.tables.query.ImplicitQueryJoinForSecurityLock;
 import com.kingsrook.qqq.backend.core.model.actions.tables.query.JoinsContext;
 import com.kingsrook.qqq.backend.core.model.actions.tables.query.QFilterOrderBy;
 import com.kingsrook.qqq.backend.core.model.actions.tables.query.QQueryFilter;
@@ -230,9 +231,16 @@ public class MemoryRecordStore
       }
       else
       {
-         if(CollectionUtils.nullSafeHasContents(input.getQueryJoins()))
+         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+         // use joinsContext's query joins (which have enriched metadata from cloning), but exclude implicit security joins  //
+         // that JoinsContext added — those are handled separately via the security filter and validateSecurityFields calls. //
+         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+         List<QueryJoin> nonSecurityQueryJoins = joinsContext.getQueryJoins().stream()
+            .filter(qj -> !(qj instanceof ImplicitQueryJoinForSecurityLock))
+            .toList();
+         if(CollectionUtils.nullSafeHasContents(nonSecurityQueryJoins))
          {
-            tableData = buildJoinCrossProduct(input.getTable(), input.getQueryJoins());
+            tableData = buildJoinCrossProduct(input.getTable(), nonSecurityQueryJoins);
          }
       }
 

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/modules/backend/implementations/memory/MemoryRecordStore.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/modules/backend/implementations/memory/MemoryRecordStore.java
@@ -116,12 +116,15 @@ public class MemoryRecordStore
 
    public static final ListingHash<Class<? extends AbstractActionInput>, AbstractActionInput> actionInputs = new ListingHash<>();
 
-   //////////////////////////////////////////////////////////////////////
-   // to slow-roll this change in capability, set it as a feature-flag //
-   // on the MemoryRecordStore singleton instance.  This should allow  //
-   // an individual test, for example, to toggle it, then reset it.    //
-   //////////////////////////////////////////////////////////////////////
-   public static boolean BUILD_JOIN_CROSS_PRODUCT_FROM_JOIN_CONTEXT_DEFAULT = false;
+   ////////////////////////////////////////////////////////////////////////
+   // this flag controls whether MemoryRecordStore builds its join cross //
+   // product from the JoinsContext's query joins (which includes joins  //
+   // needed for security) or from the QueryInput's query joins (which   //
+   // only has explicitly-requested joins).  Originally defaulted to     //
+   // false while we gained confidence; now defaults to true.  If a test //
+   // needs the old behavior, it can set this to false on the singleton. //
+   ////////////////////////////////////////////////////////////////////////
+   public static boolean BUILD_JOIN_CROSS_PRODUCT_FROM_JOIN_CONTEXT_DEFAULT = true;
    private       boolean buildJoinCrossProductFromJoinContext               = BUILD_JOIN_CROSS_PRODUCT_FROM_JOIN_CONTEXT_DEFAULT;
 
 
@@ -218,30 +221,19 @@ public class MemoryRecordStore
       QQueryFilter filter       = clonedOrNewFilter(input.getFilter());
       JoinsContext joinsContext = new JoinsContext(QContext.getQInstance(), input.getTableName(), input.getQueryJoins(), filter);
 
-      /////////////////////////////////////////////////////////////////////////////////////////////////
-      // if we every wanted or needed per-query control here, that could look like:                  //
-      // || input.hasFlag(MemoryBackendQueryActionFlags.BUILD_JOIN_CROSS_PRODUCT_FROM_JOIN_CONTEXT)) //
-      /////////////////////////////////////////////////////////////////////////////////////////////////
-      if(buildJoinCrossProductFromJoinContext)
+      ////////////////////////////////////////////////////////////////////////////////
+      // see comment on #withBuildJoinCrossProductFromJoinContext for full history. //
+      // when true, use joinsContext's query joins (includes security joins);       //
+      // when false, use the input's query joins (original behavior).               //
+      ////////////////////////////////////////////////////////////////////////////////
+      List<QueryJoin> queryJoins = buildJoinCrossProductFromJoinContext ? joinsContext.getQueryJoins() : input.getQueryJoins();
+
+      ///////////////////////////////////////////////////////////////////////////////////////////
+      // if there are query joins, then use the cross product of those joins as the table data //
+      ///////////////////////////////////////////////////////////////////////////////////////////
+      if(CollectionUtils.nullSafeHasContents(queryJoins))
       {
-         if(CollectionUtils.nullSafeHasContents(joinsContext.getQueryJoins()))
-         {
-            tableData = buildJoinCrossProduct(input.getTable(), joinsContext.getQueryJoins());
-         }
-      }
-      else
-      {
-         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-         // use joinsContext's query joins (which have enriched metadata from cloning), but exclude implicit security joins  //
-         // that JoinsContext added — those are handled separately via the security filter and validateSecurityFields calls. //
-         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-         List<QueryJoin> nonSecurityQueryJoins = joinsContext.getQueryJoins().stream()
-            .filter(qj -> !(qj instanceof ImplicitQueryJoinForSecurityLock))
-            .toList();
-         if(CollectionUtils.nullSafeHasContents(nonSecurityQueryJoins))
-         {
-            tableData = buildJoinCrossProduct(input.getTable(), nonSecurityQueryJoins);
-         }
+         tableData = buildJoinCrossProduct(input.getTable(), queryJoins, joinsContext);
       }
 
       ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -250,7 +242,7 @@ public class MemoryRecordStore
       ///////////////////////////////////////////////////////////////////////////////////////////////////////
       Map<String, QTableMetaData> personalizedTables = new HashMap<>();
       personalizedTables.put(input.getTableName(), input.getTableMetaData());
-      for(QueryJoin queryJoin : joinsContext.getQueryJoins())
+      for(QueryJoin queryJoin : CollectionUtils.nonNullList(queryJoins))
       {
          QTableMetaData joinTable = QContext.getQInstance().getTable(queryJoin.getJoinTable());
          joinTable = TableMetaDataPersonalizerAction.execute(new TableMetaDataPersonalizerInput().withTableMetaData(joinTable).withInputSource(input.getInputSource()));
@@ -338,8 +330,12 @@ public class MemoryRecordStore
     *
     * <p>Note that INNER & LEFT joins should work but, RIGHT joins will not work
     * at this time.</p>
+    *
+    * @param table the main-table being queried for
+    * @param queryJoins the list of joins to cross against the main table.
+    * @param joinsContext more details about the join.
     *******************************************************************************/
-   private Collection<QRecord> buildJoinCrossProduct(QTableMetaData table, List<QueryJoin> queryJoins) throws QException
+   private Collection<QRecord> buildJoinCrossProduct(QTableMetaData table, List<QueryJoin> queryJoins, JoinsContext joinsContext) throws QException
    {
       QInstance qInstance = QContext.getQInstance();
 
@@ -356,7 +352,13 @@ public class MemoryRecordStore
       {
          QTableMetaData      nextTable        = qInstance.getTable(queryJoin.getJoinTable());
          Collection<QRecord> nextTableRecords = getTableData(nextTable).values();
-         QJoinMetaData       joinMetaData     = Objects.requireNonNull(queryJoin.getJoinMetaData(), () -> "Could not find a join between tables [" + leftTable + "][" + queryJoin.getJoinTable() + "]");
+
+         QJoinMetaData joinMetaData = queryJoin.getJoinMetaData();
+         if(joinMetaData == null)
+         {
+            joinMetaData = joinsContext.findJoinMetaData(table.getName(), queryJoin.getJoinTable(), false);
+            Objects.requireNonNull(joinMetaData, () -> "Did not have, and could not find a join metaData between tables in QueryJoin object base=[" + leftTable + "], join=[" + queryJoin.getJoinTable() + "]");
+         }
 
          List<QRecord> nextLevelProduct = new ArrayList<>();
          for(QRecord productRecord : crossProduct)
@@ -1283,18 +1285,19 @@ public class MemoryRecordStore
    /*******************************************************************************
     * Fluent setter for buildJoinCrossProductFromJoinContext
     *
-    * @param buildJoinCrossProductFromJoinContext
-    * The original implementation of this class only tried to build cross-products
-    * for joins based on QueryJoin objects directly added to the QueryInput.
-    * However, this meant that if a join was needed for the security key on a table,
-    * that this table wouldn't be included in the join cross product, thus incorrect
-    * query results could be returned.
+    * <p>The original implementation of this class only built cross-products for
+    * joins explicitly added to the QueryInput.  This meant that joins needed for
+    * security locks (added by JoinsContext) were not included, causing incorrect
+    * query results for tables with join-chain security locks.</p>
     *
-    * <p>This new behavior (to use joins from the JoinContext, which means, it includes
-    * joins needed for security) seems like the obviously more correct way to do it -
-    * but, it is a potentially breaking change, so we want to slow-roll it out.
-    * Thus, an application (or a unit test) can opt-in to the new behavior by
-    * setting this field to true on a MemoryRecordStore singleton instance.</p>
+    * <p>The corrected behavior (using joins from JoinsContext, which includes
+    * security joins) is now the default ({@code true}).  Originally this defaulted
+    * to {@code false} while we gained confidence, but after fixing a double-flip
+    * bug in {@code JoinsContext.fillInMissingJoinMetaData} that was causing
+    * multi-hop security chain failures, all tests pass with the new default.</p>
+    *
+    * <p>If a test needs the old behavior, it can set this to {@code false} on the
+    * MemoryRecordStore singleton instance.</p>
     *
     * @return this
     *******************************************************************************/

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContextTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContextTest.java
@@ -22,6 +22,7 @@
 package com.kingsrook.qqq.backend.core.model.actions.tables.query;
 
 
+import java.util.ArrayList;
 import java.util.List;
 import com.kingsrook.qqq.backend.core.BaseTest;
 import com.kingsrook.qqq.backend.core.context.QContext;
@@ -1255,10 +1256,10 @@ class JoinsContextTest extends BaseTest
 
       JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(queryJoin), new QQueryFilter());
 
-      /////////////////////////////////////////////////////////////////////////
-      // after construction, the context's copy of the join should have its  //
-      // metadata flipped: leftTable should now be employee (main table)     //
-      /////////////////////////////////////////////////////////////////////////
+      ////////////////////////////////////////////////////////////////////////
+      // after construction, the context's copy of the join should have its //
+      // metadata flipped: leftTable should now be employee (main table)    //
+      ////////////////////////////////////////////////////////////////////////
       QJoinMetaData resolvedMetaData = joinsContext.getQueryJoins().get(0).getJoinMetaData();
       assertNotNull(resolvedMetaData, "JoinMetaData should still be present after flip");
       assertEquals(EMPLOYEE_TABLE, resolvedMetaData.getLeftTable(), "Left table should be employee (flipped)");
@@ -1572,31 +1573,31 @@ class JoinsContextTest extends BaseTest
          .withSelect(true)
          .withJoinMetaData(instance.getJoin(DEPARTMENT_JOIN_EMPLOYEE));
 
-      List<QueryJoin> sharedQueryJoins = new java.util.ArrayList<>(List.of(userJoin));
+      List<QueryJoin> sharedQueryJoins = new ArrayList<>(List.of(userJoin));
       int originalSize = sharedQueryJoins.size();
 
-      /////////////////////////////////////////////////////////////////////////////////
-      // First construction: restricted session with specific company key values.    //
-      // This should NOT modify the shared list.                                     //
-      /////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////////////////////////////////////////////////
+      // First construction: restricted session with specific company key values. //
+      // This should NOT modify the shared list.                                  //
+      //////////////////////////////////////////////////////////////////////////////
       QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 42));
       new JoinsContext(instance, DEPARTMENT_TABLE, sharedQueryJoins, new QQueryFilter());
 
       assertEquals(originalSize, sharedQueryJoins.size(),
          "JoinsContext should not add security joins to the caller's queryJoins list");
 
-      /////////////////////////////////////////////////////////////////////////////////
-      // Second construction: all-access session.                                    //
-      // Because the list was mutated above, the stale INNER join with companyId     //
-      // IN (42) is found "already in the query" and reused without re-evaluation.   //
-      /////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////////////////////////////////////////////////////
+      // Second construction: all-access session.                                  //
+      // Because the list was mutated above, the stale INNER join with companyId   //
+      // IN (42) is found "already in the query" and reused without re-evaluation. //
+      ///////////////////////////////////////////////////////////////////////////////
       QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_COMPANY_ALL_ACCESS, true));
       JoinsContext allAccessContext = new JoinsContext(instance, DEPARTMENT_TABLE, sharedQueryJoins, new QQueryFilter());
 
-      ///////////////////////////////////////////////////////////////////////////////
-      // With all-access, the security join should be LEFT (not INNER) and should  //
-      // have no security criteria on it.                                          //
-      ///////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////////////////////////////////////////////////
+      // With all-access, the security join should be LEFT (not INNER) and should //
+      // have no security criteria on it.                                         //
+      //////////////////////////////////////////////////////////////////////////////
       QueryJoin securityJoin = allAccessContext.getQueryJoins().stream()
          .filter(qj -> qj instanceof ImplicitQueryJoinForSecurityLock)
          .findFirst()

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContextTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContextTest.java
@@ -1574,10 +1574,10 @@ class JoinsContextTest extends BaseTest
 
       assertEquals(2, securityJoins.size(), "Should have 2 security joins for a 2-hop chain");
 
-      ////////////////////////////////////////////////////////////////////////////////////////
-      // Hop 1: employee → department.  The original departmentEmployees join has            //
+      //////////////////////////////////////////////////////////////////////////////////////////
+      // Hop 1: employee → department.  The original departmentEmployees join has             //
       // left=department, right=employee, so it gets flipped: left=employee, right=department //
-      ////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////////////////////////////////////////////////////////////
       QueryJoin hop1 = securityJoins.get(0);
       QJoinMetaData hop1Meta = hop1.getJoinMetaData();
       assertNotNull(hop1Meta);
@@ -1586,13 +1586,13 @@ class JoinsContextTest extends BaseTest
       assertEquals(DEPARTMENT_TABLE, hop1Meta.getRightTable(),
          "Hop 1 right table should be department");
 
-      ///////////////////////////////////////////////////////////////////////////////////////////
-      // Hop 2: department → company.  The original companyDepartments join has                 //
-      // left=company, right=department, so it gets flipped: left=department, right=company.    //
-      // Before the fix, fillInMissingJoinMetaData would double-flip this back to the original  //
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      // Hop 2: department → company.  The original companyDepartments join has                  //
+      // left=company, right=department, so it gets flipped: left=department, right=company.     //
+      // Before the fix, fillInMissingJoinMetaData would double-flip this back to the original   //
       // orientation (left=company, right=department), because it couldn't see that "department" //
-      // was already in the query under the aliased hop-1 join.                                 //
-      ///////////////////////////////////////////////////////////////////////////////////////////
+      // was already in the query under the aliased hop-1 join.                                  //
+      /////////////////////////////////////////////////////////////////////////////////////////////
       QueryJoin hop2 = securityJoins.get(1);
       QJoinMetaData hop2Meta = hop2.getJoinMetaData();
       assertNotNull(hop2Meta);
@@ -1601,11 +1601,11 @@ class JoinsContextTest extends BaseTest
       assertEquals(COMPANY_TABLE, hop2Meta.getRightTable(),
          "Hop 2 right table should be company");
 
-      /////////////////////////////////////////////////////////////////////////////////////
-      // Also verify the joinOn fields are oriented correctly after the (single) flip.   //
+      ////////////////////////////////////////////////////////////////////////////////////////////
+      // Also verify the joinOn fields are oriented correctly after the (single) flip.          //
       // Original companyDepartments: JoinOn(id, companyId) meaning company.id = dept.companyId //
-      // After flip: JoinOn(companyId, id) meaning dept.companyId = company.id           //
-      /////////////////////////////////////////////////////////////////////////////////////
+      // After flip: JoinOn(companyId, id) meaning dept.companyId = company.id                  //
+      ////////////////////////////////////////////////////////////////////////////////////////////
       JoinOn hop2JoinOn = hop2Meta.getJoinOns().get(0);
       assertEquals("companyId", hop2JoinOn.getLeftField(),
          "After flip, left field should be companyId (department's FK)");
@@ -1635,12 +1635,12 @@ class JoinsContextTest extends BaseTest
 
       useInstance(instance);
 
-      /////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////////////////////////////////////////////////////
       // With a restricted session, the security criteria should be placed on the     //
       // last security join in the chain (the one closest to the company table).      //
       // For join-chain locks, criteria go on the QueryJoin's securityCriteria field, //
       // not in the main WHERE filter.                                                //
-      /////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////////////////////////////////////////////////////
       QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 42));
       JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(), new QQueryFilter());
 
@@ -1656,9 +1656,9 @@ class JoinsContextTest extends BaseTest
       assertThat(lastHop.getSecurityCriteria().get(0).getFieldName()).contains("id");
       assertThat(lastHop.getSecurityCriteria().get(0).getValues()).contains(42);
 
-      ////////////////////////////////////////////////////////////////////////////////////////
-      // now with all-access, verify the security joins are LEFT and have no criteria.      //
-      ////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////////////////////////////////////////////////////////
+      // now with all-access, verify the security joins are LEFT and have no criteria. //
+      ///////////////////////////////////////////////////////////////////////////////////
       QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_COMPANY_ALL_ACCESS, true));
       JoinsContext allAccessContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(), new QQueryFilter());
 
@@ -1707,24 +1707,24 @@ class JoinsContextTest extends BaseTest
 
       assertEquals(3, securityJoins.size(), "Should have 3 security joins for a 3-hop chain");
 
-      //////////////////////////////////////////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////
       // Hop 1: employeeDetail → employee (flipped from employee→employeeDetail) //
-      //////////////////////////////////////////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////
       QJoinMetaData hop1Meta = securityJoins.get(0).getJoinMetaData();
       assertEquals(EMPLOYEE_DETAIL_TABLE, hop1Meta.getLeftTable());
       assertEquals(EMPLOYEE_TABLE, hop1Meta.getRightTable());
 
-      ///////////////////////////////////////////////////////////////////////////
-      // Hop 2: employee → department (flipped from department→employee)       //
-      ///////////////////////////////////////////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////
+      // Hop 2: employee → department (flipped from department→employee) //
+      /////////////////////////////////////////////////////////////////////
       QJoinMetaData hop2Meta = securityJoins.get(1).getJoinMetaData();
       assertEquals(EMPLOYEE_TABLE, hop2Meta.getLeftTable(),
          "Hop 2 left should be employee (not double-flipped back to department)");
       assertEquals(DEPARTMENT_TABLE, hop2Meta.getRightTable());
 
-      ///////////////////////////////////////////////////////////////////////////
-      // Hop 3: department → company (flipped from company→department)         //
-      ///////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////////////////////////////////////////
+      // Hop 3: department → company (flipped from company→department) //
+      ///////////////////////////////////////////////////////////////////
       QJoinMetaData hop3Meta = securityJoins.get(2).getJoinMetaData();
       assertEquals(DEPARTMENT_TABLE, hop3Meta.getLeftTable(),
          "Hop 3 left should be department (not double-flipped back to company)");

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContextTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContextTest.java
@@ -304,13 +304,9 @@ class JoinsContextTest extends BaseTest
       /////////////////////////////////////////////////////////////////////////////
       QueryJoin detailJoin = new QueryJoin().withJoinTable(EMPLOYEE_DETAIL_TABLE);
 
-      ////////////////////////////////////////////////////////////////////////////////////
-      // constructing this joinsContext has the side-effect of modifying the QueryJoin  //
-      // with its QJoinMetaData (thus, no need to capture the constructed JoinsContext) //
-      ////////////////////////////////////////////////////////////////////////////////////
-      new JoinsContext(instance, EMPLOYEE_TABLE, List.of(detailJoin), new QQueryFilter());
+      JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(detailJoin), new QQueryFilter());
 
-      QJoinMetaData resolvedMetaData = detailJoin.getJoinMetaData();
+      QJoinMetaData resolvedMetaData = joinsContext.getQueryJoins().get(0).getJoinMetaData();
       assertNotNull(resolvedMetaData, "JoinMetaData should have been auto-filled");
       assertEquals(EMPLOYEE_TABLE, resolvedMetaData.getLeftTable());
       assertEquals(EMPLOYEE_DETAIL_TABLE, resolvedMetaData.getRightTable());
@@ -1260,10 +1256,10 @@ class JoinsContextTest extends BaseTest
       JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(queryJoin), new QQueryFilter());
 
       /////////////////////////////////////////////////////////////////////////
-      // after construction, the queryJoin's metadata should have been       //
-      // flipped: its leftTable should now be employee (the main table side) //
+      // after construction, the context's copy of the join should have its  //
+      // metadata flipped: leftTable should now be employee (main table)     //
       /////////////////////////////////////////////////////////////////////////
-      QJoinMetaData resolvedMetaData = queryJoin.getJoinMetaData();
+      QJoinMetaData resolvedMetaData = joinsContext.getQueryJoins().get(0).getJoinMetaData();
       assertNotNull(resolvedMetaData, "JoinMetaData should still be present after flip");
       assertEquals(EMPLOYEE_TABLE, resolvedMetaData.getLeftTable(), "Left table should be employee (flipped)");
       assertEquals(DEPARTMENT_TABLE, resolvedMetaData.getRightTable(), "Right table should be department (flipped)");
@@ -1532,6 +1528,85 @@ class JoinsContextTest extends BaseTest
       }
 
       return false;
+   }
+
+
+
+   /*******************************************************************************
+    ** Demonstrates the shared-mutable-state bug: when the same queryJoins list
+    ** is passed to JoinsContext twice (as happens with ChildRecordListRenderer's
+    ** widget metadata), ImplicitQueryJoinForSecurityLock objects from the first
+    ** construction leak into the list and are reused by the second construction
+    ** without re-evaluating security.
+    **
+    ** Scenario (mirrors the ColdTrack-Live lineItem widget bug):
+    ** - department table has a companyKey security lock via joinNameChain
+    ** - First JoinsContext: restricted session (companyKey = [42]) → adds an
+    **   INNER security join with criteria companyId IN (42) to the shared list
+    ** - Second JoinsContext: all-access session → should produce a LEFT join
+    **   with no criteria, but finds the stale INNER join and reuses it
+    *******************************************************************************/
+   @Test
+   void testSharedQueryJoinListIsNotMutatedBetweenConstructions() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(SECURITY_KEY_TYPE_COMPANY)
+         .withAllAccessKeyName(SECURITY_KEY_COMPANY_ALL_ACCESS));
+
+      instance.getTable(DEPARTMENT_TABLE).withRecordSecurityLock(new RecordSecurityLock()
+         .withSecurityKeyType(SECURITY_KEY_TYPE_COMPANY)
+         .withFieldName("company.id")
+         .withJoinNameChain(List.of(COMPANY_JOIN_DEPARTMENT)));
+
+      useInstance(instance);
+
+      /////////////////////////////////////////////////////////////////////////////////
+      // Simulate a shared queryJoins list (like the one stored in widget metadata). //
+      // It starts with a single user-defined join, analogous to the item LEFT JOIN  //
+      // in the lineItems widget.                                                    //
+      /////////////////////////////////////////////////////////////////////////////////
+      QueryJoin userJoin = new QueryJoin()
+         .withJoinTable(EMPLOYEE_TABLE)
+         .withType(QueryJoin.Type.LEFT)
+         .withSelect(true)
+         .withJoinMetaData(instance.getJoin(DEPARTMENT_JOIN_EMPLOYEE));
+
+      List<QueryJoin> sharedQueryJoins = new java.util.ArrayList<>(List.of(userJoin));
+      int originalSize = sharedQueryJoins.size();
+
+      /////////////////////////////////////////////////////////////////////////////////
+      // First construction: restricted session with specific company key values.    //
+      // This should NOT modify the shared list.                                     //
+      /////////////////////////////////////////////////////////////////////////////////
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 42));
+      new JoinsContext(instance, DEPARTMENT_TABLE, sharedQueryJoins, new QQueryFilter());
+
+      assertEquals(originalSize, sharedQueryJoins.size(),
+         "JoinsContext should not add security joins to the caller's queryJoins list");
+
+      /////////////////////////////////////////////////////////////////////////////////
+      // Second construction: all-access session.                                    //
+      // Because the list was mutated above, the stale INNER join with companyId     //
+      // IN (42) is found "already in the query" and reused without re-evaluation.   //
+      /////////////////////////////////////////////////////////////////////////////////
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_COMPANY_ALL_ACCESS, true));
+      JoinsContext allAccessContext = new JoinsContext(instance, DEPARTMENT_TABLE, sharedQueryJoins, new QQueryFilter());
+
+      ///////////////////////////////////////////////////////////////////////////////
+      // With all-access, the security join should be LEFT (not INNER) and should  //
+      // have no security criteria on it.                                          //
+      ///////////////////////////////////////////////////////////////////////////////
+      QueryJoin securityJoin = allAccessContext.getQueryJoins().stream()
+         .filter(qj -> qj instanceof ImplicitQueryJoinForSecurityLock)
+         .findFirst()
+         .orElse(null);
+
+      assertNotNull(securityJoin, "All-access context should still have a security join");
+      assertEquals(QueryJoin.Type.LEFT, securityJoin.getType(),
+         "All-access session should produce a LEFT join, not INNER");
+      assertTrue(securityJoin.getSecurityCriteria().isEmpty(),
+         "All-access session should have no security criteria on the join");
    }
 
 }

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContextTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/model/actions/tables/query/JoinsContextTest.java
@@ -1534,6 +1534,206 @@ class JoinsContextTest extends BaseTest
 
 
    /*******************************************************************************
+    ** Verify that a 2-hop security lock chain produces correctly-oriented join
+    ** metadata for both hops.  Before the fix in fillInMissingJoinMetaData, the
+    ** second hop's metadata was double-flipped: it was correctly flipped during
+    ** ensureRecordSecurityLockIsRepresented, then incorrectly flipped again by
+    ** fillInMissingJoinMetaData because it couldn't see that the intermediate
+    ** table was already in the query under an alias.
+    **
+    ** Scenario:
+    ** - main table = employee
+    ** - security lock on company.id via joinNameChain [companyDepartments, departmentEmployees]
+    ** - reversed chain walks: employee → department (hop 1), department → company (hop 2)
+    ** - hop 1 creates an aliased join like "department_forSecurityJoin_departmentEmployees"
+    ** - hop 2's metadata should have leftTable=department, rightTable=company
+    **   (i.e., still flipped from the original companyDepartments direction)
+    **   but was getting double-flipped back to leftTable=company, rightTable=department
+    *******************************************************************************/
+   @Test
+   void testTwoHopSecurityLockJoinMetaDataNotDoubleFlipped() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(SECURITY_KEY_TYPE_COMPANY)
+         .withAllAccessKeyName(SECURITY_KEY_COMPANY_ALL_ACCESS));
+
+      instance.getTable(EMPLOYEE_TABLE).withRecordSecurityLock(new RecordSecurityLock()
+         .withSecurityKeyType(SECURITY_KEY_TYPE_COMPANY)
+         .withFieldName("company.id")
+         .withJoinNameChain(List.of(COMPANY_JOIN_DEPARTMENT, DEPARTMENT_JOIN_EMPLOYEE)));
+
+      useInstance(instance);
+
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 42));
+      JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(), new QQueryFilter());
+
+      List<QueryJoin> securityJoins = joinsContext.getQueryJoins().stream()
+         .filter(qj -> qj instanceof ImplicitQueryJoinForSecurityLock)
+         .toList();
+
+      assertEquals(2, securityJoins.size(), "Should have 2 security joins for a 2-hop chain");
+
+      ////////////////////////////////////////////////////////////////////////////////////////
+      // Hop 1: employee → department.  The original departmentEmployees join has            //
+      // left=department, right=employee, so it gets flipped: left=employee, right=department //
+      ////////////////////////////////////////////////////////////////////////////////////////
+      QueryJoin hop1 = securityJoins.get(0);
+      QJoinMetaData hop1Meta = hop1.getJoinMetaData();
+      assertNotNull(hop1Meta);
+      assertEquals(EMPLOYEE_TABLE, hop1Meta.getLeftTable(),
+         "Hop 1 left table should be employee (main table, flipped from original)");
+      assertEquals(DEPARTMENT_TABLE, hop1Meta.getRightTable(),
+         "Hop 1 right table should be department");
+
+      ///////////////////////////////////////////////////////////////////////////////////////////
+      // Hop 2: department → company.  The original companyDepartments join has                 //
+      // left=company, right=department, so it gets flipped: left=department, right=company.    //
+      // Before the fix, fillInMissingJoinMetaData would double-flip this back to the original  //
+      // orientation (left=company, right=department), because it couldn't see that "department" //
+      // was already in the query under the aliased hop-1 join.                                 //
+      ///////////////////////////////////////////////////////////////////////////////////////////
+      QueryJoin hop2 = securityJoins.get(1);
+      QJoinMetaData hop2Meta = hop2.getJoinMetaData();
+      assertNotNull(hop2Meta);
+      assertEquals(DEPARTMENT_TABLE, hop2Meta.getLeftTable(),
+         "Hop 2 left table should be department (flipped from original companyDepartments)");
+      assertEquals(COMPANY_TABLE, hop2Meta.getRightTable(),
+         "Hop 2 right table should be company");
+
+      /////////////////////////////////////////////////////////////////////////////////////
+      // Also verify the joinOn fields are oriented correctly after the (single) flip.   //
+      // Original companyDepartments: JoinOn(id, companyId) meaning company.id = dept.companyId //
+      // After flip: JoinOn(companyId, id) meaning dept.companyId = company.id           //
+      /////////////////////////////////////////////////////////////////////////////////////
+      JoinOn hop2JoinOn = hop2Meta.getJoinOns().get(0);
+      assertEquals("companyId", hop2JoinOn.getLeftField(),
+         "After flip, left field should be companyId (department's FK)");
+      assertEquals("id", hop2JoinOn.getRightField(),
+         "After flip, right field should be id (company's PK)");
+   }
+
+
+
+   /*******************************************************************************
+    ** Same 2-hop chain scenario, but verifying the security filter criteria are
+    ** correctly placed.  This matters for RDBMS backends, where the security filter
+    ** becomes part of the WHERE clause and must reference the correct alias.
+    *******************************************************************************/
+   @Test
+   void testTwoHopSecurityLockFilterCriteria() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(SECURITY_KEY_TYPE_COMPANY)
+         .withAllAccessKeyName(SECURITY_KEY_COMPANY_ALL_ACCESS));
+
+      instance.getTable(EMPLOYEE_TABLE).withRecordSecurityLock(new RecordSecurityLock()
+         .withSecurityKeyType(SECURITY_KEY_TYPE_COMPANY)
+         .withFieldName("company.id")
+         .withJoinNameChain(List.of(COMPANY_JOIN_DEPARTMENT, DEPARTMENT_JOIN_EMPLOYEE)));
+
+      useInstance(instance);
+
+      /////////////////////////////////////////////////////////////////////////////////////
+      // With a restricted session, the security criteria should be placed on the     //
+      // last security join in the chain (the one closest to the company table).      //
+      // For join-chain locks, criteria go on the QueryJoin's securityCriteria field, //
+      // not in the main WHERE filter.                                                //
+      /////////////////////////////////////////////////////////////////////////////////////
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 42));
+      JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(), new QQueryFilter());
+
+      List<QueryJoin> restrictedSecurityJoins = joinsContext.getQueryJoins().stream()
+         .filter(qj -> qj instanceof ImplicitQueryJoinForSecurityLock)
+         .toList();
+
+      assertEquals(2, restrictedSecurityJoins.size());
+
+      QueryJoin lastHop = restrictedSecurityJoins.get(restrictedSecurityJoins.size() - 1);
+      assertFalse(lastHop.getSecurityCriteria().isEmpty(),
+         "Last security join should have security criteria for restricted session");
+      assertThat(lastHop.getSecurityCriteria().get(0).getFieldName()).contains("id");
+      assertThat(lastHop.getSecurityCriteria().get(0).getValues()).contains(42);
+
+      ////////////////////////////////////////////////////////////////////////////////////////
+      // now with all-access, verify the security joins are LEFT and have no criteria.      //
+      ////////////////////////////////////////////////////////////////////////////////////////
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_COMPANY_ALL_ACCESS, true));
+      JoinsContext allAccessContext = new JoinsContext(instance, EMPLOYEE_TABLE, List.of(), new QQueryFilter());
+
+      List<QueryJoin> allAccessSecurityJoins = allAccessContext.getQueryJoins().stream()
+         .filter(qj -> qj instanceof ImplicitQueryJoinForSecurityLock)
+         .toList();
+
+      assertEquals(2, allAccessSecurityJoins.size());
+      for(QueryJoin join : allAccessSecurityJoins)
+      {
+         assertEquals(QueryJoin.Type.LEFT, join.getType(),
+            "All-access session should produce LEFT joins, not INNER");
+         assertTrue(join.getSecurityCriteria().isEmpty(),
+            "All-access session should have no security criteria");
+      }
+   }
+
+
+
+   /*******************************************************************************
+    ** 3-hop security lock chain: employeeDetail → employee → department → company.
+    ** Ensures fillInMissingJoinMetaData handles even deeper chains correctly,
+    ** where each hop's intermediate table is under a unique alias.
+    *******************************************************************************/
+   @Test
+   void testThreeHopSecurityLockJoinMetaDataOrientation() throws QException
+   {
+      QInstance instance = buildBaseInstance();
+      instance.addSecurityKeyType(new QSecurityKeyType()
+         .withName(SECURITY_KEY_TYPE_COMPANY)
+         .withAllAccessKeyName(SECURITY_KEY_COMPANY_ALL_ACCESS));
+
+      instance.getTable(EMPLOYEE_DETAIL_TABLE).withRecordSecurityLock(new RecordSecurityLock()
+         .withSecurityKeyType(SECURITY_KEY_TYPE_COMPANY)
+         .withFieldName("company.id")
+         .withJoinNameChain(List.of(COMPANY_JOIN_DEPARTMENT, DEPARTMENT_JOIN_EMPLOYEE, EMPLOYEE_JOIN_EMPLOYEE_DETAIL)));
+
+      useInstance(instance);
+
+      QContext.setQSession(new QSession().withSecurityKeyValue(SECURITY_KEY_TYPE_COMPANY, 42));
+      JoinsContext joinsContext = new JoinsContext(instance, EMPLOYEE_DETAIL_TABLE, List.of(), new QQueryFilter());
+
+      List<QueryJoin> securityJoins = joinsContext.getQueryJoins().stream()
+         .filter(qj -> qj instanceof ImplicitQueryJoinForSecurityLock)
+         .toList();
+
+      assertEquals(3, securityJoins.size(), "Should have 3 security joins for a 3-hop chain");
+
+      //////////////////////////////////////////////////////////////////////////
+      // Hop 1: employeeDetail → employee (flipped from employee→employeeDetail) //
+      //////////////////////////////////////////////////////////////////////////
+      QJoinMetaData hop1Meta = securityJoins.get(0).getJoinMetaData();
+      assertEquals(EMPLOYEE_DETAIL_TABLE, hop1Meta.getLeftTable());
+      assertEquals(EMPLOYEE_TABLE, hop1Meta.getRightTable());
+
+      ///////////////////////////////////////////////////////////////////////////
+      // Hop 2: employee → department (flipped from department→employee)       //
+      ///////////////////////////////////////////////////////////////////////////
+      QJoinMetaData hop2Meta = securityJoins.get(1).getJoinMetaData();
+      assertEquals(EMPLOYEE_TABLE, hop2Meta.getLeftTable(),
+         "Hop 2 left should be employee (not double-flipped back to department)");
+      assertEquals(DEPARTMENT_TABLE, hop2Meta.getRightTable());
+
+      ///////////////////////////////////////////////////////////////////////////
+      // Hop 3: department → company (flipped from company→department)         //
+      ///////////////////////////////////////////////////////////////////////////
+      QJoinMetaData hop3Meta = securityJoins.get(2).getJoinMetaData();
+      assertEquals(DEPARTMENT_TABLE, hop3Meta.getLeftTable(),
+         "Hop 3 left should be department (not double-flipped back to company)");
+      assertEquals(COMPANY_TABLE, hop3Meta.getRightTable());
+   }
+
+
+
+   /*******************************************************************************
     ** Demonstrates the shared-mutable-state bug: when the same queryJoins list
     ** is passed to JoinsContext twice (as happens with ChildRecordListRenderer's
     ** widget metadata), ImplicitQueryJoinForSecurityLock objects from the first

--- a/qqq-backend-module-mongodb/src/test/java/com/kingsrook/qqq/backend/module/mongodb/BaseTest.java
+++ b/qqq-backend-module-mongodb/src/test/java/com/kingsrook/qqq/backend/module/mongodb/BaseTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 
@@ -64,7 +65,8 @@ public class BaseTest
          .withEnv("MONGO_INITDB_ROOT_USERNAME", TestUtils.MONGO_USERNAME)
          .withEnv("MONGO_INITDB_ROOT_PASSWORD", TestUtils.MONGO_PASSWORD)
          .withEnv("MONGO_INITDB_DATABASE", TestUtils.MONGO_DATABASE)
-         .withExposedPorts(TestUtils.MONGO_PORT);
+         .withExposedPorts(TestUtils.MONGO_PORT)
+         .waitingFor(Wait.forLogMessage("(?i).*waiting for connections.*", 1));
 
       mongoDBContainer.start();
    }

--- a/qqq-backend-module-rdbms/src/test/java/com/kingsrook/qqq/backend/module/rdbms/actions/RDBMSQueryActionJoinsTest.java
+++ b/qqq-backend-module-rdbms/src/test/java/com/kingsrook/qqq/backend/module/rdbms/actions/RDBMSQueryActionJoinsTest.java
@@ -1175,10 +1175,10 @@ public class RDBMSQueryActionJoinsTest extends RDBMSActionTest
    @Test
    void testTwoHopSecurityLockChainOnLineItemExtrinsic() throws QException
    {
-      /////////////////////////////////////////////////////////////////////////////////////
-      // insert lineItemExtrinsic rows linked to order_line rows from different stores.  //
+      //////////////////////////////////////////////////////////////////////////////////////
+      // insert lineItemExtrinsic rows linked to order_line rows from different stores.   //
       // order_line id=1 is on order 1 (store 1), order_line id=6 is on order 4 (store 2) //
-      /////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////////////////////////////////////////////////////////
       QContext.setQSession(new QSession().withSecurityKeyValue(TestUtils.SECURITY_KEY_STORE_ALL_ACCESS, true));
       new InsertAction().execute(new InsertInput(TestUtils.TABLE_NAME_LINE_ITEM_EXTRINSIC).withRecords(List.of(
          new QRecord().withValue("orderLineId", 1).withValue("key", "color").withValue("value", "red"),
@@ -1186,9 +1186,9 @@ public class RDBMSQueryActionJoinsTest extends RDBMSActionTest
          new QRecord().withValue("orderLineId", 6).withValue("key", "color").withValue("value", "blue")
       )));
 
-      ///////////////////////////////////////////////////////////////////////////////
-      // with all-access, should see all 3 rows                                   //
-      ///////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////////////////////
+      // with all-access, should see all 3 rows //
+      ////////////////////////////////////////////
       QueryInput queryInput = new QueryInput();
       queryInput.setTableName(TestUtils.TABLE_NAME_LINE_ITEM_EXTRINSIC);
       List<QRecord> allRecords = new QueryAction().execute(queryInput).getRecords();
@@ -1214,18 +1214,18 @@ public class RDBMSQueryActionJoinsTest extends RDBMSActionTest
       assertEquals(1, store2Records.size(), "Store 2 should see 1 lineItemExtrinsic row");
       assertThat(store2Records).allMatch(r -> r.getValueInteger("orderLineId").equals(6));
 
-      //////////////////////////////////////////////////////////////////////////////
-      // with store=5 (no orders), should see nothing                            //
-      //////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////////////////////
+      // with store=5 (no orders), should see nothing //
+      //////////////////////////////////////////////////
       QContext.setQSession(new QSession().withSecurityKeyValue(TestUtils.TABLE_NAME_STORE, 5));
       queryInput = new QueryInput();
       queryInput.setTableName(TestUtils.TABLE_NAME_LINE_ITEM_EXTRINSIC);
       List<QRecord> noRecords = new QueryAction().execute(queryInput).getRecords();
       assertEquals(0, noRecords.size(), "Store 5 should see no lineItemExtrinsic rows");
 
-      //////////////////////////////////////////////////////////////////////////////
-      // with no security key at all, should see nothing                         //
-      //////////////////////////////////////////////////////////////////////////////
+      /////////////////////////////////////////////////////
+      // with no security key at all, should see nothing //
+      /////////////////////////////////////////////////////
       QContext.setQSession(new QSession());
       queryInput = new QueryInput();
       queryInput.setTableName(TestUtils.TABLE_NAME_LINE_ITEM_EXTRINSIC);

--- a/qqq-backend-module-rdbms/src/test/java/com/kingsrook/qqq/backend/module/rdbms/actions/RDBMSQueryActionJoinsTest.java
+++ b/qqq-backend-module-rdbms/src/test/java/com/kingsrook/qqq/backend/module/rdbms/actions/RDBMSQueryActionJoinsTest.java
@@ -28,10 +28,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import com.kingsrook.qqq.backend.core.actions.tables.CountAction;
+import com.kingsrook.qqq.backend.core.actions.tables.InsertAction;
 import com.kingsrook.qqq.backend.core.actions.tables.QueryAction;
 import com.kingsrook.qqq.backend.core.context.QContext;
 import com.kingsrook.qqq.backend.core.exceptions.QException;
 import com.kingsrook.qqq.backend.core.model.actions.tables.count.CountInput;
+import com.kingsrook.qqq.backend.core.model.actions.tables.insert.InsertInput;
 import com.kingsrook.qqq.backend.core.model.actions.tables.query.QCriteriaOperator;
 import com.kingsrook.qqq.backend.core.model.actions.tables.query.QFilterCriteria;
 import com.kingsrook.qqq.backend.core.model.actions.tables.query.QFilterOrderBy;
@@ -1154,6 +1156,81 @@ public class RDBMSQueryActionJoinsTest extends RDBMSActionTest
       assertThat(queryOutput.getRecords()).allMatch(r -> r.getValues().containsKey("firstName"));
       assertThat(queryOutput.getRecords()).allMatch(r -> r.getValues().containsKey("id2.idNumber"));
       assertThat(queryOutput.getRecords()).allMatch(r -> r.getValues().size() == 2);
+   }
+
+
+
+   /*******************************************************************************
+    ** Exercises a 2-hop security lock chain through the RDBMS backend.
+    **
+    ** The lineItemExtrinsic table has a security lock on order.storeId via
+    ** joinNameChain [orderJoinOrderLine, orderLineJoinLineItemExtrinsic].
+    ** This means querying lineItemExtrinsic requires joining through orderLine
+    ** to order to evaluate the security lock.
+    **
+    ** This test verifies that the generated SQL correctly handles the 2-hop
+    ** chain — specifically that fillInMissingJoinMetaData does not double-flip
+    ** the second hop's join metadata, which would produce an invalid ON clause.
+    *******************************************************************************/
+   @Test
+   void testTwoHopSecurityLockChainOnLineItemExtrinsic() throws QException
+   {
+      /////////////////////////////////////////////////////////////////////////////////////
+      // insert lineItemExtrinsic rows linked to order_line rows from different stores.  //
+      // order_line id=1 is on order 1 (store 1), order_line id=6 is on order 4 (store 2) //
+      /////////////////////////////////////////////////////////////////////////////////////
+      QContext.setQSession(new QSession().withSecurityKeyValue(TestUtils.SECURITY_KEY_STORE_ALL_ACCESS, true));
+      new InsertAction().execute(new InsertInput(TestUtils.TABLE_NAME_LINE_ITEM_EXTRINSIC).withRecords(List.of(
+         new QRecord().withValue("orderLineId", 1).withValue("key", "color").withValue("value", "red"),
+         new QRecord().withValue("orderLineId", 1).withValue("key", "size").withValue("value", "large"),
+         new QRecord().withValue("orderLineId", 6).withValue("key", "color").withValue("value", "blue")
+      )));
+
+      ///////////////////////////////////////////////////////////////////////////////
+      // with all-access, should see all 3 rows                                   //
+      ///////////////////////////////////////////////////////////////////////////////
+      QueryInput queryInput = new QueryInput();
+      queryInput.setTableName(TestUtils.TABLE_NAME_LINE_ITEM_EXTRINSIC);
+      List<QRecord> allRecords = new QueryAction().execute(queryInput).getRecords();
+      assertEquals(3, allRecords.size(), "All-access should see all 3 lineItemExtrinsic rows");
+
+      ///////////////////////////////////////////////////////////////////////////////
+      // with store=1, should see the 2 rows linked through order_line 1 → order 1 //
+      ///////////////////////////////////////////////////////////////////////////////
+      QContext.setQSession(new QSession().withSecurityKeyValue(TestUtils.TABLE_NAME_STORE, 1));
+      queryInput = new QueryInput();
+      queryInput.setTableName(TestUtils.TABLE_NAME_LINE_ITEM_EXTRINSIC);
+      List<QRecord> store1Records = new QueryAction().execute(queryInput).getRecords();
+      assertEquals(2, store1Records.size(), "Store 1 should see 2 lineItemExtrinsic rows");
+      assertThat(store1Records).allMatch(r -> r.getValueInteger("orderLineId").equals(1));
+
+      ///////////////////////////////////////////////////////////////////////////////
+      // with store=2, should see the 1 row linked through order_line 6 → order 4 //
+      ///////////////////////////////////////////////////////////////////////////////
+      QContext.setQSession(new QSession().withSecurityKeyValue(TestUtils.TABLE_NAME_STORE, 2));
+      queryInput = new QueryInput();
+      queryInput.setTableName(TestUtils.TABLE_NAME_LINE_ITEM_EXTRINSIC);
+      List<QRecord> store2Records = new QueryAction().execute(queryInput).getRecords();
+      assertEquals(1, store2Records.size(), "Store 2 should see 1 lineItemExtrinsic row");
+      assertThat(store2Records).allMatch(r -> r.getValueInteger("orderLineId").equals(6));
+
+      //////////////////////////////////////////////////////////////////////////////
+      // with store=5 (no orders), should see nothing                            //
+      //////////////////////////////////////////////////////////////////////////////
+      QContext.setQSession(new QSession().withSecurityKeyValue(TestUtils.TABLE_NAME_STORE, 5));
+      queryInput = new QueryInput();
+      queryInput.setTableName(TestUtils.TABLE_NAME_LINE_ITEM_EXTRINSIC);
+      List<QRecord> noRecords = new QueryAction().execute(queryInput).getRecords();
+      assertEquals(0, noRecords.size(), "Store 5 should see no lineItemExtrinsic rows");
+
+      //////////////////////////////////////////////////////////////////////////////
+      // with no security key at all, should see nothing                         //
+      //////////////////////////////////////////////////////////////////////////////
+      QContext.setQSession(new QSession());
+      queryInput = new QueryInput();
+      queryInput.setTableName(TestUtils.TABLE_NAME_LINE_ITEM_EXTRINSIC);
+      List<QRecord> emptySessionRecords = new QueryAction().execute(queryInput).getRecords();
+      assertEquals(0, emptySessionRecords.size(), "Empty session should see no lineItemExtrinsic rows");
    }
 
 }

--- a/qqq-middleware-api/src/test/java/com/kingsrook/qqq/api/middleware/specs/v1/ApiAwareTableQuerySpecV1Test.java
+++ b/qqq-middleware-api/src/test/java/com/kingsrook/qqq/api/middleware/specs/v1/ApiAwareTableQuerySpecV1Test.java
@@ -55,7 +55,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ApiAwareTableQuerySpecV1Test extends ApiAwareSpecTestBase
 {
 
-
    /***************************************************************************
     **
     ***************************************************************************/

--- a/qqq-middleware-api/src/test/java/com/kingsrook/qqq/api/middleware/specs/v1/ApiAwareTableQuerySpecV1Test.java
+++ b/qqq-middleware-api/src/test/java/com/kingsrook/qqq/api/middleware/specs/v1/ApiAwareTableQuerySpecV1Test.java
@@ -407,15 +407,14 @@ class ApiAwareTableQuerySpecV1Test extends ApiAwareSpecTestBase
          .asString();
       assert400.accept(response, "Unrecognized criteria field name: orderLine.noSuchField.");
 
-      ///////////////////////////////////////////////////////////////////////////////////////////////
-      // join for sku - should find (but... memory backend isn't joining correctly at this time... //
-      // so we'll ensure at least http 200, and trust that other backends join correctly...        //
-      ///////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////////////////////////////////////////////////
+      // join for sku - should find the 1 order that has a line with that sku. //
+      ///////////////////////////////////////////////////////////////////////////
       response = Unirest.post(getBaseUrlAndPath(TestUtils.API_PATH, TestUtils.V2023_Q1) + "/table/order/query")
          .body(JsonUtils.toJson(Map.of("filter", new QQueryFilter(new QFilterCriteria(TestUtils.TABLE_NAME_LINE_ITEM + ".sku", QCriteriaOperator.EQUALS, "BASIC1")))))
          .contentType(ContentType.APPLICATION_JSON.getMimeType())
          .asString();
-      assertOrderCount.accept(response, 0); // todo - ideally 1, but memory backend joining...
+      assertOrderCount.accept(response, 1);
 
       ///////////////////////////////
       // fetch exposed join fields //


### PR DESCRIPTION
## Summary

### Core fix: JoinsContext shared-state mutation
- **JoinsContext was mutating shared QueryJoin lists.** `JoinsContext` wrapped the caller's `queryJoins` list with `MutableList`, which delegated `add()` back to the original list. When `ChildRecordListRenderer` stored `QueryJoin` objects in widget metadata and passed the same list on every request, `JoinsContext` permanently added `ImplicitQueryJoinForSecurityLock` objects to that shared list. On subsequent requests, these stale joins were found "already in the query" and reused without re-evaluating the session's security context — causing INNER JOINs with wrong security IDs even for all-access users.
- **Fix: clone incoming QueryJoins.** Each incoming `QueryJoin` is now cloned into a new `ArrayList`, so `JoinsContext` never mutates the caller's objects. Removes the stale workaround that tried to reset `securityCriteria` on reused `QueryJoin` objects — no longer needed now that the root cause is fixed.

### JoinsContext double-flip bug in multi-hop security chains
- **`fillInMissingJoinMetaData` was double-flipping join metadata on 2+ hop security lock chains.** For a table like `lineItemExtrinsic` with a security lock via `orderLine → order`, the second hop's metadata was correctly flipped during `ensureRecordSecurityLockIsRepresented`, then incorrectly flipped *again* by `fillInMissingJoinMetaData` because it couldn't see that the intermediate table was already in the query under an alias (e.g., `orderLine_forSecurityJoin_lineItemLineItemExtrinsic`).
- **Fix: resolve aliases when checking whether a join's left table is in the query.** The existing check only compared `otherJoin.getBaseTableOrAlias()` against the raw table name. Now also resolves each join's `getJoinTableOrItsAlias()` through the alias map.
- Note: the RDBMS backend is resilient to this bug because `AbstractRDBMSAction.makeFromClause()` does its own runtime flip-correction based on the actual base table context. The memory backend's `buildJoinCrossProduct` relies on correct metadata orientation, so this fix was necessary for it.

### MemoryRecordStore join cross-product improvements
- **Flipped `buildJoinCrossProductFromJoinContext` default from `false` to `true`.**  This existing flag controls whether the memory backend builds its join cross product from the JoinsContext's query joins (which include implicit security joins) or from the QueryInput's explicit joins.  It had been defaulting to `false` because some tests failed when enabled; the root cause was the `fillInMissingJoinMetaData` double-flip bug above.  With that fixed, all tests pass and the default is now `true`.  The flag does remain though, for now, in case the old behavior is still needed for some use case(s).
- **`buildJoinCrossProduct` now accepts `JoinsContext`** and falls back to `joinsContext.findJoinMetaData()` when a QueryJoin doesn't have metadata (since the cloning fix means input QueryJoins are no longer mutated with enriched metadata).

### Unrelated
- MongoDB test flake fix (wait on container startup)
- Style cleanup (imports, flowerbox comments)

## Test plan

- [x] `JoinsContextTest.testSharedQueryJoinListIsNotMutatedBetweenConstructions` — reproduces the ColdTrack-Live widget bug
- [x] `JoinsContextTest.testTwoHopSecurityLockJoinMetaDataNotDoubleFlipped` — directly proves the double-flip fix (goes red without the fix)
- [x] `JoinsContextTest.testTwoHopSecurityLockFilterCriteria` — verifies security criteria placement for 2-hop chains
- [x] `JoinsContextTest.testThreeHopSecurityLockJoinMetaDataOrientation` — 3-hop chain (goes red without the fix)
- [x] `RDBMSQueryActionJoinsTest.testTwoHopSecurityLockChainOnLineItemExtrinsic` — end-to-end RDBMS test: inserts lineItemExtrinsic data, queries with different store security keys, verifies correct row counts
- [x] Updated `testJoinMetaDataResolution` and `testJoinMetaDataFlipping` — inspect the context's cloned copy instead of the original
- [x] `ApiAwareTableQuerySpecV1Test.testJoin` — now asserts correct join count (1) without needing to toggle the flag
- [x] `DeleteActionTest` and `InsertActionTest` pass with the default `true` without explicit flag toggles
- [x] Full `JoinsContextTest` suite (41 tests), full `qqq-backend-core` test suite pass
- [x] Full project test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
