### PR TITLE
fix(memory): clear stale display values on queried records

### DIFF
--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/modules/backend/implementations/memory/MemoryRecordStore.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/modules/backend/implementations/memory/MemoryRecordStore.java
@@ -275,10 +275,12 @@ public class MemoryRecordStore
                //////////////////////////////////////////////////////////////////////////////////
                // make sure we're not giving back records that are all full of associations... //
                // or fields that the user isn't supposed to get (e.g., from personalization)   //
+               // or old display values (or just ones that wern't requested)                   //
                //////////////////////////////////////////////////////////////////////////////////
                QRecord recordToReturn = new QRecord(qRecord);
-               stripUnrecognizedFieldsFromRecords(List.of(recordToReturn), personalizedTables, input.getTable());
                recordToReturn.setAssociatedRecords(new HashMap<>());
+               stripUnrecognizedFieldsFromRecords(List.of(recordToReturn), personalizedTables, input.getTable());
+               recordToReturn.setDisplayValues(new HashMap<>());
                records.add(recordToReturn);
             }
          }

--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/modules/backend/implementations/memory/MemoryRecordStore.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/modules/backend/implementations/memory/MemoryRecordStore.java
@@ -281,8 +281,8 @@ public class MemoryRecordStore
                // or old display values (or just ones that wern't requested)                   //
                //////////////////////////////////////////////////////////////////////////////////
                QRecord recordToReturn = new QRecord(qRecord);
-               addVirtualFieldsToRecords(List.of(recordToReturn), input.getTable());
                stripUnrecognizedFieldsFromRecords(List.of(recordToReturn), personalizedTables, input.getTable());
+               addVirtualFieldsToRecords(List.of(recordToReturn), input.getTable());
                recordToReturn.setAssociatedRecords(new HashMap<>());
                recordToReturn.setDisplayValues(new HashMap<>());
                records.add(recordToReturn);

--- a/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/modules/backend/implementations/memory/MemoryBackendModuleTest.java
+++ b/qqq-backend-core/src/test/java/com/kingsrook/qqq/backend/core/modules/backend/implementations/memory/MemoryBackendModuleTest.java
@@ -774,6 +774,64 @@ class MemoryBackendModuleTest extends BaseTest
    /*******************************************************************************
     **
     *******************************************************************************/
+   @Test
+   void testQueryDisplayValuesAreNotStale() throws QException
+   {
+      QTableMetaData table = QContext.getQInstance().getTable(TestUtils.TABLE_NAME_SHAPE);
+
+      //////////////////////////////////////////////////////////
+      // insert a record with just values (no display values) //
+      //////////////////////////////////////////////////////////
+      InsertInput insertInput = new InsertInput();
+      insertInput.setTableName(table.getName());
+      insertInput.setRecords(List.of(
+         new QRecord()
+            .withTableName(table.getName())
+            .withValue("name", "My Triangle")
+            .withValue("type", "triangle")
+            .withValue("isPolygon", true)
+      ));
+      new InsertAction().execute(insertInput);
+
+      ////////////////////////////////////////////////////////////////////////////////////////
+      // query with display values - assert we get the expected display value for isPolygon //
+      ////////////////////////////////////////////////////////////////////////////////////////
+      QueryInput queryInput = new QueryInput();
+      queryInput.setTableName(table.getName());
+      queryInput.setShouldGenerateDisplayValues(true);
+      QueryOutput queryOutput = new QueryAction().execute(queryInput);
+      assertEquals(1, queryOutput.getRecords().size());
+      assertEquals("Yes", queryOutput.getRecords().get(0).getDisplayValue("isPolygon"));
+
+      //////////////////////////////////////////////////////////////////////////////////////////////
+      // update the record - change isPolygon from true to false (just values, no display values) //
+      //////////////////////////////////////////////////////////////////////////////////////////////
+      UpdateInput updateInput = new UpdateInput();
+      updateInput.setTableName(table.getName());
+      updateInput.setRecords(List.of(new QRecord().withValue("id", 1).withValue("isPolygon", false)));
+      new UpdateAction().execute(updateInput);
+
+      ////////////////////////////////////////////////////////////////////////////////////////
+      // re-query with display values - assert the display value reflects the updated value //
+      ////////////////////////////////////////////////////////////////////////////////////////
+      queryOutput = new QueryAction().execute(queryInput);
+      assertEquals(1, queryOutput.getRecords().size());
+      assertEquals("No", queryOutput.getRecords().get(0).getDisplayValue("isPolygon"));
+
+      ///////////////////////////////////////////////////////////////////////
+      // re-query without display values - assert display values are empty //
+      ///////////////////////////////////////////////////////////////////////
+      queryInput.setShouldGenerateDisplayValues(false);
+      queryOutput = new QueryAction().execute(queryInput);
+      assertEquals(1, queryOutput.getRecords().size());
+      assertThat(queryOutput.getRecords().get(0).getDisplayValues()).isEmpty();
+   }
+
+
+
+   /*******************************************************************************
+    **
+    *******************************************************************************/
    public static class ShapeTestCustomizer extends AbstractPostQueryCustomizer
    {
       static int invocationCount        = 0;


### PR DESCRIPTION
## Summary
- Clear display values on record copies returned from `MemoryRecordStore.query()`, preventing stale display values from prior queries leaking into subsequent results
- Added end-to-end test: insert → query with display values → update → re-query to verify display values reflect current data and are absent when not requested

## Test plan
- [x] New test `testQueryDisplayValuesAreNotStale` passes in `MemoryBackendModuleTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)