### PR TITLE
feat(oauth2): add externalBaseUrl for split URL deployments

### DIFF
--- a/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/authentication/OAuth2AuthenticationMetaData.java
+++ b/qqq-backend-core/src/main/java/com/kingsrook/qqq/backend/core/model/metadata/authentication/OAuth2AuthenticationMetaData.java
@@ -32,11 +32,35 @@ import com.kingsrook.qqq.backend.core.utils.StringUtils;
 
 
 /*******************************************************************************
- ** Meta-data to provide details of an OAuth2 Authentication module
+ ** Meta-data to provide details of an OAuth2 Authentication module.
+ **
+ ** baseUrl is used by the backend server for OIDC discovery and token exchange
+ ** (server-to-server calls). In Kubernetes or environments behind a reverse proxy,
+ ** this may be an internal/cluster-local URL (e.g., http://auth-service.auth.svc/).
+ **
+ ** externalBaseUrl, if set, is the URL sent to the frontend/SPA for browser-based
+ ** OAuth2 redirects. This is needed when the backend cannot reach the OAuth2
+ ** provider via the same URL that browsers use (e.g., Calico NetworkPolicy
+ ** blocking pod-to-LoadBalancer traffic, or internal HTTP vs external HTTPS).
+ ** If not set, baseUrl is used for both purposes (backwards compatible).
  *******************************************************************************/
 public class OAuth2AuthenticationMetaData extends QAuthenticationMetaData
 {
+   ///////////////////////////////////////////////////////////////////////////////
+   // URL used by the backend for OIDC discovery and token exchange.            //
+   // In split-URL deployments, this should be the internal/cluster-reachable   //
+   // URL for the OAuth2 provider.                                              //
+   ///////////////////////////////////////////////////////////////////////////////
    private String baseUrl;
+
+   ///////////////////////////////////////////////////////////////////////////////
+   // Optional URL sent to the frontend for browser-based OAuth2 redirects.     //
+   // When set, the /metaData/authentication API response returns this value    //
+   // instead of baseUrl, allowing the SPA to redirect to a different (external //
+   // HTTPS) URL than the one the backend uses internally.                      //
+   // If not set, baseUrl is used for both backend and frontend (default).      //
+   ///////////////////////////////////////////////////////////////////////////////
+   private String externalBaseUrl;
    private String tokenUrl;
    private String clientId;
    private String scopes;
@@ -125,6 +149,37 @@ public class OAuth2AuthenticationMetaData extends QAuthenticationMetaData
    public void setBaseUrl(String baseUrl)
    {
       this.baseUrl = baseUrl;
+   }
+
+
+
+   /*******************************************************************************
+    ** Getter for externalBaseUrl
+    *******************************************************************************/
+   public String getExternalBaseUrl()
+   {
+      return (this.externalBaseUrl);
+   }
+
+
+
+   /*******************************************************************************
+    ** Setter for externalBaseUrl
+    *******************************************************************************/
+   public void setExternalBaseUrl(String externalBaseUrl)
+   {
+      this.externalBaseUrl = externalBaseUrl;
+   }
+
+
+
+   /*******************************************************************************
+    ** Fluent setter for externalBaseUrl
+    *******************************************************************************/
+   public OAuth2AuthenticationMetaData withExternalBaseUrl(String externalBaseUrl)
+   {
+      this.externalBaseUrl = externalBaseUrl;
+      return (this);
    }
 
 

--- a/qqq-middleware-javalin/src/main/java/com/kingsrook/qqq/middleware/javalin/specs/v1/responses/AuthenticationMetaDataResponseV1.java
+++ b/qqq-middleware-javalin/src/main/java/com/kingsrook/qqq/middleware/javalin/specs/v1/responses/AuthenticationMetaDataResponseV1.java
@@ -25,6 +25,7 @@ package com.kingsrook.qqq.middleware.javalin.specs.v1.responses;
 import com.kingsrook.qqq.backend.core.model.metadata.authentication.Auth0AuthenticationMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.authentication.OAuth2AuthenticationMetaData;
 import com.kingsrook.qqq.backend.core.model.metadata.authentication.QAuthenticationMetaData;
+import com.kingsrook.qqq.backend.core.utils.StringUtils;
 import com.kingsrook.qqq.middleware.javalin.executors.io.AuthenticationMetaDataOutputInterface;
 import com.kingsrook.qqq.middleware.javalin.schemabuilder.ToSchema;
 import com.kingsrook.qqq.middleware.javalin.schemabuilder.annotations.OpenAPIDescription;
@@ -326,7 +327,7 @@ public class AuthenticationMetaDataResponseV1 implements AuthenticationMetaDataO
          OAuth2Values oauth2Values = new OAuth2Values();
          values = oauth2Values;
          oauth2Values.setClientId(oauth2MetaData.getClientId());
-         oauth2Values.setBaseUrl(oauth2MetaData.getBaseUrl());
+         oauth2Values.setBaseUrl(StringUtils.hasContent(oauth2MetaData.getExternalBaseUrl()) ? oauth2MetaData.getExternalBaseUrl() : oauth2MetaData.getBaseUrl());
          oauth2Values.setScopes(oauth2MetaData.getScopes());
       }
       else if(qAuthenticationMetaData instanceof Auth0AuthenticationMetaData auth0MetaData)

--- a/qqq-middleware-javalin/src/test/java/com/kingsrook/qqq/middleware/javalin/specs/v1/AuthenticationMetaDataSpecV1Test.java
+++ b/qqq-middleware-javalin/src/test/java/com/kingsrook/qqq/middleware/javalin/specs/v1/AuthenticationMetaDataSpecV1Test.java
@@ -22,9 +22,11 @@
 package com.kingsrook.qqq.middleware.javalin.specs.v1;
 
 
+import com.kingsrook.qqq.backend.core.model.metadata.authentication.OAuth2AuthenticationMetaData;
 import com.kingsrook.qqq.backend.core.utils.JsonUtils;
 import com.kingsrook.qqq.middleware.javalin.specs.AbstractEndpointSpec;
 import com.kingsrook.qqq.middleware.javalin.specs.SpecTestBase;
+import com.kingsrook.qqq.middleware.javalin.specs.v1.responses.AuthenticationMetaDataResponseV1;
 import kong.unirest.HttpResponse;
 import kong.unirest.Unirest;
 import org.json.JSONObject;
@@ -75,6 +77,45 @@ class AuthenticationMetaDataSpecV1Test extends SpecTestBase
       assertNotNull(jsonObject);
       assertTrue(jsonObject.has("name"));
       assertTrue(jsonObject.has("type"));
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that when externalBaseUrl is not set, the response uses baseUrl.
+    *******************************************************************************/
+   @Test
+   void testOAuth2Response_noExternalBaseUrl_usesBaseUrl()
+   {
+      OAuth2AuthenticationMetaData metaData = new OAuth2AuthenticationMetaData()
+         .withBaseUrl("http://internal.auth.local/oauth");
+      metaData.setName("test");
+
+      AuthenticationMetaDataResponseV1 response = new AuthenticationMetaDataResponseV1();
+      response.setAuthenticationMetaData(metaData);
+
+      AuthenticationMetaDataResponseV1.OAuth2Values values = (AuthenticationMetaDataResponseV1.OAuth2Values) response.getValues();
+      assertEquals("http://internal.auth.local/oauth", values.getBaseUrl());
+   }
+
+
+
+   /*******************************************************************************
+    ** Test that when externalBaseUrl is set, the response uses it instead of baseUrl.
+    *******************************************************************************/
+   @Test
+   void testOAuth2Response_withExternalBaseUrl_usesExternalBaseUrl()
+   {
+      OAuth2AuthenticationMetaData metaData = new OAuth2AuthenticationMetaData()
+         .withBaseUrl("http://internal.auth.local/oauth")
+         .withExternalBaseUrl("https://auth.example.com/oauth");
+      metaData.setName("test");
+
+      AuthenticationMetaDataResponseV1 response = new AuthenticationMetaDataResponseV1();
+      response.setAuthenticationMetaData(metaData);
+
+      AuthenticationMetaDataResponseV1.OAuth2Values values = (AuthenticationMetaDataResponseV1.OAuth2Values) response.getValues();
+      assertEquals("https://auth.example.com/oauth", values.getBaseUrl());
    }
 
 }


### PR DESCRIPTION
## Summary

- Adds optional `externalBaseUrl` field to `OAuth2AuthenticationMetaData`
- When set, the `/metaData/authentication` API response returns `externalBaseUrl` as the `baseUrl` value sent to the frontend
- Backend OIDC discovery and token exchange continue using `baseUrl` (unchanged)
- If `externalBaseUrl` is not set, behavior is identical to before (backwards compatible)

This solves Kubernetes deployments (Calico + MetalLB) where pods cannot reach LoadBalancer VIPs, requiring separate internal (HTTP) and external (HTTPS) URLs for the OAuth2 provider.

## Test plan

- [x] Unit test: OAuth2 metadata without externalBaseUrl returns baseUrl (backwards compat)
- [x] Unit test: OAuth2 metadata with externalBaseUrl returns it instead of baseUrl
- [x] Existing auth metadata endpoint test still passes
- [ ] CI build passes

Closes #415